### PR TITLE
chore: add code 2

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/cache/RevocationsCache.java
+++ b/src/main/java/com/dreamsportslabs/guardian/cache/RevocationsCache.java
@@ -1,0 +1,53 @@
+package com.dreamsportslabs.guardian.cache;
+
+import com.dreamsportslabs.guardian.dao.RevocationDao;
+import com.dreamsportslabs.guardian.utils.VertxUtil;
+import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.rxjava3.core.Vertx;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Singleton
+public class RevocationsCache {
+  private final AsyncLoadingCache<String, List<String>> cache;
+  private static final String CACHE_NAME = "REVOCATION_CACHE";
+  private static final long REVOCATIONS_EXPIRY = 120;
+
+  @Inject
+  public RevocationsCache(RevocationDao revocationDao, Vertx vertx) {
+    this.cache = getOrCreateCacheInSharedData(revocationDao, vertx);
+  }
+
+  private AsyncLoadingCache<String, List<String>> getOrCreateCacheInSharedData(
+      RevocationDao revocationDao, Vertx vertx) {
+    return VertxUtil.getOrCreateSharedData(
+        vertx.getDelegate(),
+        CACHE_NAME,
+        () ->
+            Caffeine.newBuilder()
+                .executor(
+                    cmd -> {
+                      Objects.requireNonNull(Vertx.currentContext());
+                      Vertx.currentContext().runOnContext(v -> cmd.run());
+                    })
+                .expireAfterWrite(REVOCATIONS_EXPIRY, TimeUnit.SECONDS)
+                .buildAsync(getLoader(revocationDao)));
+  }
+
+  private AsyncCacheLoader<String, List<String>> getLoader(RevocationDao revocationDao) {
+    return (tenantId, executor) ->
+        revocationDao.getRevocations(tenantId).toCompletionStage().toCompletableFuture();
+  }
+
+  public Single<List<String>> getRevocationList(String key) {
+    return Single.fromCompletionStage(this.cache.get(key));
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/cache/TenantCache.java
+++ b/src/main/java/com/dreamsportslabs/guardian/cache/TenantCache.java
@@ -1,0 +1,49 @@
+package com.dreamsportslabs.guardian.cache;
+
+import com.dreamsportslabs.guardian.config.tenant.TenantConfig;
+import com.dreamsportslabs.guardian.dao.ConfigDao;
+import com.dreamsportslabs.guardian.injection.GuiceInjector;
+import com.dreamsportslabs.guardian.registry.Registry;
+import com.dreamsportslabs.guardian.registry.RegistryInit;
+import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TenantCache {
+  private final AsyncLoadingCache<String, TenantConfig> cache;
+  private static TenantCache tenantCache;
+  private final Registry registry;
+
+  private TenantCache(int refreshInterval) {
+    this.cache =
+        Caffeine.newBuilder()
+            .refreshAfterWrite(Duration.ofSeconds(refreshInterval))
+            .buildAsync(getLoader(GuiceInjector.getGuiceInjector().getInstance(ConfigDao.class)));
+    this.registry = GuiceInjector.getGuiceInjector().getInstance(Registry.class);
+  }
+
+  public static synchronized TenantCache getInstance(int refreshInterval) {
+    if (tenantCache == null) {
+      tenantCache = new TenantCache(refreshInterval);
+    }
+
+    return tenantCache;
+  }
+
+  public Single<TenantConfig> getTenantConfig(String tenantId) {
+    return Single.fromCompletionStage(cache.get(tenantId));
+  }
+
+  private AsyncCacheLoader<String, TenantConfig> getLoader(ConfigDao configDao) {
+    return (tenantId, executor) ->
+        configDao
+            .getTenantConfig(tenantId)
+            .map(config -> RegistryInit.initializeRegistry(registry, config))
+            .toCompletionStage()
+            .toCompletableFuture();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/application/Config.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/application/Config.java
@@ -1,0 +1,16 @@
+package com.dreamsportslabs.guardian.config.application;
+
+import io.vertx.core.http.HttpServerOptions;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class Config {
+  @NotNull private HttpServerOptions httpServerOptions;
+  @NotNull @Valid private MySQLConfig mySQLConfig;
+  @NotNull @Valid private WebClientConfig webClientConfig;
+  @NotNull @Valid private RedisConfig redisConfig;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/application/MySQLConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/application/MySQLConfig.java
@@ -1,0 +1,21 @@
+package com.dreamsportslabs.guardian.config.application;
+
+import io.vertx.mysqlclient.MySQLConnectOptions;
+import io.vertx.sqlclient.PoolOptions;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class MySQLConfig {
+  private MySQLBaseConfig readerConfig;
+  private MySQLBaseConfig writerConfig;
+
+  @Data
+  @NoArgsConstructor
+  public static class MySQLBaseConfig {
+    private MySQLConnectOptions connectOptions;
+    private PoolOptions poolOptions;
+    private Integer retryCount;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/application/RedisConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/application/RedisConfig.java
@@ -1,0 +1,13 @@
+package com.dreamsportslabs.guardian.config.application;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class RedisConfig {
+  private String host;
+  private int port = 6379;
+  private int maxPoolSize = 10;
+  private String type;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/application/WebClientConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/application/WebClientConfig.java
@@ -1,0 +1,13 @@
+package com.dreamsportslabs.guardian.config.application;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class WebClientConfig {
+  private Integer maxPoolSize;
+  private Integer keepAliveTimeout;
+  private Integer idleTimeout;
+  private Boolean keepAlive;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/AuthCodeConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/AuthCodeConfig.java
@@ -1,0 +1,9 @@
+package com.dreamsportslabs.guardian.config.tenant;
+
+import lombok.Data;
+
+@Data
+public class AuthCodeConfig {
+  private int length;
+  private int ttl;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/EmailConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/EmailConfig.java
@@ -1,0 +1,14 @@
+package com.dreamsportslabs.guardian.config.tenant;
+
+import java.util.HashMap;
+import lombok.Data;
+
+@Data
+public class EmailConfig {
+  private String host;
+  private int port;
+  private String sendEmailPath;
+  private boolean isSslEnabled;
+  private String templateName;
+  private HashMap<String, String> templateParams;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/FbConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/FbConfig.java
@@ -1,0 +1,9 @@
+package com.dreamsportslabs.guardian.config.tenant;
+
+import lombok.Data;
+
+@Data
+public class FbConfig {
+  private String appId;
+  private String appSecret;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/GoogleConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/GoogleConfig.java
@@ -1,0 +1,9 @@
+package com.dreamsportslabs.guardian.config.tenant;
+
+import lombok.Data;
+
+@Data
+public class GoogleConfig {
+  private String clientId;
+  private String clientSecret;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/OtpConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/OtpConfig.java
@@ -1,0 +1,15 @@
+package com.dreamsportslabs.guardian.config.tenant;
+
+import java.util.HashMap;
+import lombok.Data;
+
+@Data
+public class OtpConfig {
+  private Integer otpLength;
+  private Integer tryLimit;
+  private Boolean isOtpMocked;
+  private Integer resendLimit;
+  private Integer otpResendInterval;
+  private Integer otpValidity;
+  private HashMap<String, String> whitelistedInputs;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/RsaKey.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/RsaKey.java
@@ -1,0 +1,11 @@
+package com.dreamsportslabs.guardian.config.tenant;
+
+import lombok.Data;
+
+@Data
+public class RsaKey {
+  private String publicKey;
+  private String privateKey;
+  private String kid;
+  private Boolean current = false;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/SmsConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/SmsConfig.java
@@ -1,0 +1,14 @@
+package com.dreamsportslabs.guardian.config.tenant;
+
+import java.util.HashMap;
+import lombok.Data;
+
+@Data
+public class SmsConfig {
+  private String host;
+  private int port;
+  private String sendSmsPath;
+  private boolean isSslEnabled;
+  private String templateName;
+  private HashMap<String, String> templateParams;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/TenantConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/TenantConfig.java
@@ -1,0 +1,20 @@
+package com.dreamsportslabs.guardian.config.tenant;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@Builder
+public class TenantConfig {
+  private String tenantId;
+  private AuthCodeConfig authCodeConfig;
+  private EmailConfig emailConfig;
+  private FbConfig fbConfig;
+  private GoogleConfig googleConfig;
+  private SmsConfig smsConfig;
+  private OtpConfig otpConfig;
+  private UserConfig userConfig;
+  private TokenConfig tokenConfig;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/TokenConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/TokenConfig.java
@@ -1,0 +1,15 @@
+package com.dreamsportslabs.guardian.config.tenant;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class TokenConfig {
+  private String algorithm;
+  private String issuer;
+  private Integer accessTokenExpiry;
+  private Integer refreshTokenExpiry;
+  private Integer idTokenExpiry;
+  private List<String> idTokenClaims;
+  private List<RsaKey> rsaKeys;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/UserConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/UserConfig.java
@@ -1,0 +1,14 @@
+package com.dreamsportslabs.guardian.config.tenant;
+
+import lombok.Data;
+
+@Data
+public class UserConfig {
+  private String host;
+  private int port;
+  private Boolean isSslEnabled;
+  private String createUserPath;
+  private String getUserPath;
+  private String authenticateUserPath;
+  private String addProviderPath;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/ConfigDao.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/ConfigDao.java
@@ -1,0 +1,112 @@
+package com.dreamsportslabs.guardian.dao;
+
+import static com.dreamsportslabs.guardian.dao.query.ConfigQuery.AUTH_CODE_CONFIG;
+import static com.dreamsportslabs.guardian.dao.query.ConfigQuery.EMAIL_CONFIG;
+import static com.dreamsportslabs.guardian.dao.query.ConfigQuery.FB_AUTH_CONFIG;
+import static com.dreamsportslabs.guardian.dao.query.ConfigQuery.GOOGLE_AUTH_CONFIG;
+import static com.dreamsportslabs.guardian.dao.query.ConfigQuery.OTP_CONFIG;
+import static com.dreamsportslabs.guardian.dao.query.ConfigQuery.SMS_CONFIG;
+import static com.dreamsportslabs.guardian.dao.query.ConfigQuery.TOKEN_CONFIG;
+import static com.dreamsportslabs.guardian.dao.query.ConfigQuery.USER_CONFIG;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_REQUEST;
+
+import com.dreamsportslabs.guardian.client.MysqlClient;
+import com.dreamsportslabs.guardian.config.tenant.AuthCodeConfig;
+import com.dreamsportslabs.guardian.config.tenant.EmailConfig;
+import com.dreamsportslabs.guardian.config.tenant.FbConfig;
+import com.dreamsportslabs.guardian.config.tenant.GoogleConfig;
+import com.dreamsportslabs.guardian.config.tenant.OtpConfig;
+import com.dreamsportslabs.guardian.config.tenant.SmsConfig;
+import com.dreamsportslabs.guardian.config.tenant.TenantConfig;
+import com.dreamsportslabs.guardian.config.tenant.TokenConfig;
+import com.dreamsportslabs.guardian.config.tenant.UserConfig;
+import com.dreamsportslabs.guardian.utils.JsonUtils;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.rxjava3.sqlclient.Tuple;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class ConfigDao {
+  private final MysqlClient mysqlClient;
+
+  public Single<TenantConfig> getTenantConfig(String tenantId) {
+    TenantConfig.TenantConfigBuilder builder = TenantConfig.builder().tenantId(tenantId);
+    List<Completable> configSources =
+        List.of(
+            appendAuthCodeConfig(tenantId, builder),
+            appendEmailConfig(tenantId, builder),
+            appendUserConfig(tenantId, builder),
+            appendTokenConfig(tenantId, builder),
+            appendFbConfig(tenantId, builder),
+            appendGoogleConfig(tenantId, builder),
+            appendSmsConfig(tenantId, builder),
+            appendOtpConfig(tenantId, builder));
+    return Completable.merge(configSources)
+        .andThen(Single.defer(() -> Single.just(builder.build())));
+  }
+
+  private Completable appendAuthCodeConfig(
+      String tenantId, TenantConfig.TenantConfigBuilder builder) {
+    return getConfigFromDb(tenantId, AuthCodeConfig.class, AUTH_CODE_CONFIG)
+        .map(builder::authCodeConfig)
+        .ignoreElement();
+  }
+
+  private Completable appendEmailConfig(String tenantId, TenantConfig.TenantConfigBuilder builder) {
+    return getConfigFromDb(tenantId, EmailConfig.class, EMAIL_CONFIG)
+        .map(builder::emailConfig)
+        .ignoreElement();
+  }
+
+  private Completable appendOtpConfig(String tenantId, TenantConfig.TenantConfigBuilder builder) {
+    return getConfigFromDb(tenantId, OtpConfig.class, OTP_CONFIG)
+        .map(builder::otpConfig)
+        .ignoreElement();
+  }
+
+  private Completable appendUserConfig(String tenantId, TenantConfig.TenantConfigBuilder builder) {
+    return getConfigFromDb(tenantId, UserConfig.class, USER_CONFIG)
+        .map(builder::userConfig)
+        .ignoreElement();
+  }
+
+  private Completable appendTokenConfig(String tenantId, TenantConfig.TenantConfigBuilder builder) {
+    return getConfigFromDb(tenantId, TokenConfig.class, TOKEN_CONFIG)
+        .map(builder::tokenConfig)
+        .ignoreElement();
+  }
+
+  private Completable appendFbConfig(String tenantId, TenantConfig.TenantConfigBuilder builder) {
+    return getConfigFromDb(tenantId, FbConfig.class, FB_AUTH_CONFIG)
+        .map(builder::fbConfig)
+        .ignoreElement();
+  }
+
+  private Completable appendGoogleConfig(
+      String tenantId, TenantConfig.TenantConfigBuilder builder) {
+    return getConfigFromDb(tenantId, GoogleConfig.class, GOOGLE_AUTH_CONFIG)
+        .map(builder::googleConfig)
+        .ignoreElement();
+  }
+
+  private Completable appendSmsConfig(String tenantId, TenantConfig.TenantConfigBuilder builder) {
+    return getConfigFromDb(tenantId, SmsConfig.class, SMS_CONFIG)
+        .map(builder::smsConfig)
+        .ignoreElement();
+  }
+
+  private <T> Single<T> getConfigFromDb(String tenantId, Class<T> configType, String query) {
+    return mysqlClient
+        .getReaderPool()
+        .preparedQuery(query)
+        .execute(Tuple.of(tenantId))
+        .filter(rowSet -> rowSet.size() > 0)
+        .switchIfEmpty(Single.error(INVALID_REQUEST.getCustomException("No config found")))
+        .map(rows -> JsonUtils.rowSetToList(rows, configType).get(0));
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/PasswordlessDao.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/PasswordlessDao.java
@@ -1,0 +1,53 @@
+package com.dreamsportslabs.guardian.dao;
+
+import static com.dreamsportslabs.guardian.constant.Constants.CACHE_KEY_STATE;
+import static com.dreamsportslabs.guardian.constant.Constants.EXPIRY_OPTION_REDIS;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INTERNAL_SERVER_ERROR;
+
+import com.dreamsportslabs.guardian.dao.model.PasswordlessModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.rxjava3.redis.client.Command;
+import io.vertx.rxjava3.redis.client.Redis;
+import io.vertx.rxjava3.redis.client.Request;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class PasswordlessDao {
+  private final Redis redisClient;
+  private final ObjectMapper objectMapper;
+
+  public Maybe<PasswordlessModel> getPasswordlessModel(String state, String tenantId) {
+    return redisClient
+        .rxSend(Request.cmd(Command.GET).arg(getCacheKey(tenantId, state)))
+        .map(response -> objectMapper.readValue(response.toString(), PasswordlessModel.class));
+  }
+
+  @SneakyThrows
+  public Single<PasswordlessModel> setPasswordlessModel(PasswordlessModel model, String tenantId) {
+    return redisClient
+        .rxSend(
+            Request.cmd(Command.SET)
+                .arg(getCacheKey(tenantId, model.getState()))
+                .arg(objectMapper.writeValueAsString(model))
+                .arg(EXPIRY_OPTION_REDIS)
+                // Todo: arbitrary expiry to eventually expire, > allowed max otp validity
+                .arg(3600))
+        .onErrorResumeNext(err -> Maybe.error(INTERNAL_SERVER_ERROR.getException(err)))
+        .map(response -> model)
+        .toSingle();
+  }
+
+  public void deletePasswordlessModel(String state, String tenantId) {
+    redisClient.rxSend(Request.cmd(Command.DEL).arg(getCacheKey(tenantId, state))).subscribe();
+  }
+
+  private String getCacheKey(String tenantId, String state) {
+    return CACHE_KEY_STATE + "_" + tenantId + "_" + state;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/RefreshTokenDao.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/RefreshTokenDao.java
@@ -1,0 +1,79 @@
+package com.dreamsportslabs.guardian.dao;
+
+import static com.dreamsportslabs.guardian.dao.query.RefreshTokenSql.GET_ALL_REFRESH_TOKENS_FOR_USER;
+import static com.dreamsportslabs.guardian.dao.query.RefreshTokenSql.INVALIDATE_ALL_REFRESH_TOKENS_FOR_USER;
+import static com.dreamsportslabs.guardian.dao.query.RefreshTokenSql.INVALIDATE_REFRESH_TOKEN;
+import static com.dreamsportslabs.guardian.dao.query.RefreshTokenSql.SAVE_REFRESH_TOKEN;
+import static com.dreamsportslabs.guardian.dao.query.RefreshTokenSql.VALIDATE_REFRESH_TOKEN;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INTERNAL_SERVER_ERROR;
+
+import com.dreamsportslabs.guardian.client.MysqlClient;
+import com.dreamsportslabs.guardian.dao.model.RefreshTokenModel;
+import com.dreamsportslabs.guardian.utils.JsonUtils;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.rxjava3.sqlclient.Tuple;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @__({@Inject}))
+public class RefreshTokenDao {
+  private final MysqlClient mysqlClient;
+
+  public Completable saveRefreshToken(RefreshTokenModel refreshTokenModel) {
+    return mysqlClient
+        .getWriterPool()
+        .preparedQuery(SAVE_REFRESH_TOKEN)
+        .rxExecute(
+            Tuple.tuple(
+                Arrays.asList(
+                    refreshTokenModel.getTenantId(),
+                    refreshTokenModel.getUserId(),
+                    refreshTokenModel.getRefreshToken(),
+                    refreshTokenModel.getRefreshTokenExp(),
+                    refreshTokenModel.getSource(),
+                    refreshTokenModel.getDeviceName(),
+                    refreshTokenModel.getLocation(),
+                    refreshTokenModel.getIp())))
+        .onErrorResumeNext(err -> Single.error(INTERNAL_SERVER_ERROR.getException(err)))
+        .ignoreElement();
+  }
+
+  public Maybe<String> getRefreshToken(String refreshToken, String tenantId) {
+    return mysqlClient
+        .getReaderPool()
+        .preparedQuery(VALIDATE_REFRESH_TOKEN)
+        .rxExecute(Tuple.of(tenantId, refreshToken))
+        .filter(rowSet -> rowSet.size() > 0)
+        .map(rowSet -> JsonUtils.rowSetToList(rowSet, String.class).get(0));
+  }
+
+  public Completable invalidateRefreshToken(String refreshToken, String tenantId) {
+    return mysqlClient
+        .getWriterPool()
+        .preparedQuery(INVALIDATE_REFRESH_TOKEN)
+        .rxExecute(Tuple.of(tenantId, refreshToken))
+        .ignoreElement();
+  }
+
+  public Completable invalidateAllRefreshTokensForUser(String userId, String tenantId) {
+    return mysqlClient
+        .getWriterPool()
+        .preparedQuery(INVALIDATE_ALL_REFRESH_TOKENS_FOR_USER)
+        .rxExecute(Tuple.of(tenantId, userId))
+        .ignoreElement();
+  }
+
+  public Single<List<String>> getRefreshTokens(String userId, String tenantId) {
+    return mysqlClient
+        .getReaderPool()
+        .preparedQuery(GET_ALL_REFRESH_TOKENS_FOR_USER)
+        .rxExecute(Tuple.of(tenantId, userId))
+        .map(rows -> JsonUtils.rowSetToList(rows, String.class));
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/RevocationDao.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/RevocationDao.java
@@ -1,0 +1,80 @@
+package com.dreamsportslabs.guardian.dao;
+
+import static com.dreamsportslabs.guardian.constant.Constants.NEG_INF;
+import static com.dreamsportslabs.guardian.constant.Constants.REDIS_OPTION_BYSCORE;
+import static com.dreamsportslabs.guardian.constant.Constants.REVOCATIONS_KEY_APPLICATION_ID_INDEX;
+import static com.dreamsportslabs.guardian.constant.Constants.REVOCATIONS_KEY_SCORE_END_INDEX;
+import static com.dreamsportslabs.guardian.constant.Constants.REVOCATIONS_KEY_SCORE_START_INDEX;
+import static com.dreamsportslabs.guardian.constant.Constants.REVOCATIONS_KEY_SEPARATOR;
+import static com.dreamsportslabs.guardian.constant.Constants.REVOCATIONS_REDIS_KEY_PREFIX;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INTERNAL_SERVER_ERROR;
+
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.rxjava3.redis.client.Command;
+import io.vertx.rxjava3.redis.client.Redis;
+import io.vertx.rxjava3.redis.client.Request;
+import io.vertx.rxjava3.redis.client.Response;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class RevocationDao {
+  final Redis redisClient;
+
+  public Single<List<String>> getRevocations(String key) {
+    return redisClient
+        .rxSend(getRedisRequestToGetRevocations(key))
+        .switchIfEmpty(Single.error(INTERNAL_SERVER_ERROR.getException()))
+        .map(this::mapRedisResponseToList)
+        .onErrorResumeNext(err -> Single.error(INTERNAL_SERVER_ERROR.getException(err)));
+  }
+
+  public void addExpiredRefreshTokensInSortedSet(
+      long currentTimeStamp, List<String> refreshTokens, String tenantId) {
+    Request req = Request.cmd(Command.ZADD).arg(getRevocationsCacheKey(tenantId));
+
+    for (String sessionId : refreshTokens) {
+      req.arg(currentTimeStamp);
+      req.arg(sessionId);
+    }
+    redisClient.rxSend(req).subscribe();
+  }
+
+  public void removeExpiredRefreshTokensFromSortedSet(
+      long currentTimeStamp, long accessTokenExpiry, String tenantId) {
+    long expiryTimeStamp = currentTimeStamp - accessTokenExpiry;
+    redisClient
+        .rxSend(
+            Request.cmd(Command.ZREMRANGEBYSCORE)
+                .arg(getRevocationsCacheKey(tenantId))
+                .arg(NEG_INF)
+                .arg(expiryTimeStamp))
+        .subscribe();
+  }
+
+  private List<String> mapRedisResponseToList(Response resp) {
+    List<String> revocations = new ArrayList<>();
+    resp.forEach(item -> revocations.add(item.toString()));
+    return revocations;
+  }
+
+  private Request getRedisRequestToGetRevocations(String key) {
+    String[] revocationKeyParts = key.split(REVOCATIONS_KEY_SEPARATOR);
+    String tenantId = revocationKeyParts[REVOCATIONS_KEY_APPLICATION_ID_INDEX];
+    String fromEpoch = revocationKeyParts[REVOCATIONS_KEY_SCORE_START_INDEX];
+    String toEpoch = revocationKeyParts[REVOCATIONS_KEY_SCORE_END_INDEX];
+    return Request.cmd(Command.ZRANGE)
+        .arg(getRevocationsCacheKey(tenantId))
+        .arg(fromEpoch)
+        .arg(toEpoch)
+        .arg(REDIS_OPTION_BYSCORE);
+  }
+
+  private String getRevocationsCacheKey(String applicationId) {
+    return REVOCATIONS_REDIS_KEY_PREFIX + REVOCATIONS_KEY_SEPARATOR + applicationId;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/model/CodeModel.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/model/CodeModel.java
@@ -1,0 +1,19 @@
+package com.dreamsportslabs.guardian.dao.model;
+
+import com.dreamsportslabs.guardian.dto.request.MetaInfo;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Builder
+@Jacksonized
+public class CodeModel {
+  private String code;
+  private Map<String, Object> user;
+  private MetaInfo metaInfo;
+  private Integer expiry;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/model/PasswordlessModel.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/model/PasswordlessModel.java
@@ -1,0 +1,102 @@
+package com.dreamsportslabs.guardian.dao.model;
+
+import static com.dreamsportslabs.guardian.constant.Constants.USERID;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.USER_EXISTS;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.USER_NOT_EXISTS;
+
+import com.dreamsportslabs.guardian.constant.Contact;
+import com.dreamsportslabs.guardian.constant.Flow;
+import com.dreamsportslabs.guardian.dto.request.MetaInfo;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.jackson.Jacksonized;
+import lombok.extern.slf4j.Slf4j;
+
+@Builder
+@Getter
+@Slf4j
+@Jacksonized
+public class PasswordlessModel {
+  private String state;
+  private String otp;
+  @Builder.Default private Boolean isOtpMocked = false;
+  @Builder.Default private Integer tries = 0;
+  @Builder.Default private Integer resends = 0;
+  private Long resendAfter;
+  private Integer resendInterval;
+  private Integer maxTries;
+  private Integer maxResends;
+
+  @Setter private Map<String, Object> user;
+  private Map<String, String> headers;
+
+  private List<Contact> contacts;
+  private Flow flow;
+  private String responseType;
+  @Builder.Default private MetaInfo metaInfo = new MetaInfo();
+  @Builder.Default private Long createdAtEpoch = Instant.now().toEpochMilli();
+  private Long expiry;
+
+  private Map<String, Object> additionalInfo;
+
+  PasswordlessModel(
+      String state,
+      String otp,
+      Boolean isOtpMocked,
+      Integer tries,
+      Integer resends,
+      Long resendAfter,
+      Integer resendInterval,
+      Integer maxTries,
+      Integer maxResends,
+      Map<String, Object> user,
+      Map<String, String> headers,
+      List<Contact> contacts,
+      Flow flow,
+      String responseType,
+      MetaInfo metaInfo,
+      Long createdAtEpoch,
+      Long expiry,
+      Map<String, Object> additionalInfo) {
+    if (flow.equals(Flow.SIGNUP) && user.get(USERID) != null) {
+      throw USER_EXISTS.getException();
+    }
+
+    if (flow.equals(Flow.SIGNIN) && user.get(USERID) == null) {
+      throw USER_NOT_EXISTS.getException();
+    }
+    this.state = state;
+    this.otp = otp;
+    this.isOtpMocked = isOtpMocked;
+    this.tries = tries;
+    this.resends = resends;
+    this.resendAfter = resendAfter;
+    this.resendInterval = resendInterval;
+    this.maxTries = maxTries;
+    this.maxResends = maxResends;
+    this.user = user;
+    this.headers = headers;
+    this.contacts = contacts;
+    this.flow = flow;
+    this.responseType = responseType;
+    this.metaInfo = metaInfo;
+    this.createdAtEpoch = createdAtEpoch;
+    this.expiry = expiry;
+    this.additionalInfo = additionalInfo;
+  }
+
+  public PasswordlessModel incRetry() {
+    this.tries += 1;
+    return this;
+  }
+
+  public PasswordlessModel updateResend() {
+    this.resendAfter = System.currentTimeMillis() / 1000 + resendInterval;
+    this.resends += 1;
+    return this;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/model/RefreshTokenModel.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/model/RefreshTokenModel.java
@@ -1,0 +1,17 @@
+package com.dreamsportslabs.guardian.dao.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class RefreshTokenModel {
+  private String tenantId;
+  private String userId;
+  private String refreshToken;
+  private long refreshTokenExp;
+  private String location;
+  private String deviceName;
+  private String ip;
+  private String source;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dto/UserDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/UserDto.java
@@ -1,0 +1,40 @@
+package com.dreamsportslabs.guardian.dto;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UserDto {
+  private String username;
+  private String password;
+  private String name;
+  private String firstName;
+  private String middleName;
+  private String lastName;
+  private String picture;
+  private String email;
+  private String phoneNumber;
+  private Provider provider;
+
+  @JsonIgnore @Builder.Default private Map<String, Object> additionalInfo = new HashMap<>();
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalInfo() {
+    return additionalInfo;
+  }
+
+  @JsonAnySetter
+  public void addAdditionalInfo(String name, Object value) {
+    additionalInfo.put(name, value);
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dto/request/V1AuthFbRequestDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/request/V1AuthFbRequestDto.java
@@ -1,0 +1,53 @@
+package com.dreamsportslabs.guardian.dto.request;
+
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_REQUEST;
+
+import com.dreamsportslabs.guardian.constant.Constants;
+import com.dreamsportslabs.guardian.constant.Flow;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class V1AuthFbRequestDto {
+  private String accessToken;
+  private String responseType;
+  private Flow flow;
+  private MetaInfo metaInfo;
+  @JsonIgnore private Map<String, Object> additionalInfo;
+
+  public V1AuthFbRequestDto() {
+    this.flow = Flow.SIGNINUP;
+    this.metaInfo = new MetaInfo();
+    this.additionalInfo = new HashMap<>();
+  }
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalInfo() {
+    return this.additionalInfo;
+  }
+
+  @JsonAnySetter
+  public void addAdditionalInfo(String key, Object value) {
+    this.additionalInfo.put(key, value);
+  }
+
+  public void validate() {
+    if (responseType == null) {
+      throw INVALID_REQUEST.getCustomException("Invalid response type");
+    }
+
+    if (accessToken == null) {
+      throw INVALID_REQUEST.getCustomException("Invalid access token");
+    }
+
+    if (!Constants.fbAuthResponseTypes.contains(responseType)) {
+      throw INVALID_REQUEST.getCustomException("Invalid response type");
+    }
+  }
+}


### PR DESCRIPTION
## **User description**
@coderabbitai ignore


___

## **CodeAnt-AI Description**
- Added comprehensive caching and configuration management for tenants, including asynchronous caches for revocations and tenant configs using Caffeine and Vertx.
- Introduced a full suite of configuration classes for application and tenant-level settings, covering MySQL, Redis, WebClient, authentication, email, SMS, OTP, and token management.
- Implemented DAOs for passwordless authentication, refresh token management, and revocation handling, supporting both MySQL and Redis backends with RxJava for async operations.
- Added data models and DTOs for code-based and passwordless authentication, refresh tokens, and user data, with extensible and validated structures.
- Provided validation and utility logic for authentication flows, including Facebook integration.

This PR establishes the foundational infrastructure for tenant-aware configuration, caching, and authentication state management. It introduces robust, extensible models and DAOs, enabling scalable and maintainable authentication and authorization flows across the application.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>25 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>RevocationsCache.java</strong><dd><code>Add asynchronous revocations caching with Caffeine and Vertx</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/cache/RevocationsCache.java
<li>Introduced a new <code>RevocationsCache</code> class for caching revocation lists <br>per tenant.<br> <li> Utilizes Caffeine's <code>AsyncLoadingCache</code> with Vertx integration for <br>asynchronous cache loading.<br> <li> Provides a method to retrieve revocation lists as RxJava <code>Single</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-768789c8a63c5b1f0d0fb4524d422bca323554247ad2a13dbb86fdda8822f828">+53/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>TenantCache.java</strong><dd><code>Introduce tenant configuration caching with refresh support</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/cache/TenantCache.java
<li>Added a <code>TenantCache</code> class for caching tenant configuration objects.<br> <li> Implements singleton pattern with refresh interval support.<br> <li> Uses Caffeine's <code>AsyncLoadingCache</code> and integrates with Guice for <br>dependency injection.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-123327102ffc3b0383ed5c80cdf138258131fa1e9af053a845b292ee7a7b0ced">+49/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Config.java</strong><dd><code>Add application-level configuration class with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/application/Config.java
<li>Added a new <code>Config</code> class representing application-level configuration.<br> <li> Includes fields for HTTP server, MySQL, WebClient, and Redis <br>configurations.<br> <li> Uses validation annotations for required fields.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-b139811e78c0dc0fb4d1b839f61ba71d718ac5a2be11fbcd5c6531b2020feea3">+16/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>MySQLConfig.java</strong><dd><code>Add MySQL configuration structure with reader/writer separation</code></dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/application/MySQLConfig.java
<li>Introduced <code>MySQLConfig</code> class for MySQL connection settings.<br> <li> Supports separate reader and writer configurations.<br> <li> Nested static class for base configuration options.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-2377cb40a209b91ecd353bca189e290b1721f70d3b578655e350a2869d401865">+21/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RedisConfig.java</strong><dd><code>Add Redis configuration class for connection settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/application/RedisConfig.java
<li>Added <code>RedisConfig</code> class for Redis connection settings.<br> <li> Includes host, port, pool size, and type fields.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-b5faaf7369e1e5530ad27b38d47a03e75a24c750cbb6efd123c4a8935ef57e9b">+13/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>WebClientConfig.java</strong><dd><code>Add WebClient configuration class for HTTP client options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/application/WebClientConfig.java
<li>Introduced <code>WebClientConfig</code> class for web client connection settings.<br> <li> Contains pool size, keep-alive, and timeout options.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-29a70aef5db2fcb5e3c5783532fe6adc8de4b28b3c36baf071e530c172aea34f">+13/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>AuthCodeConfig.java</strong><dd><code>Add AuthCode configuration class for tenant settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/tenant/AuthCodeConfig.java
<li>Added <code>AuthCodeConfig</code> class for authentication code settings.<br> <li> Includes code length and TTL fields.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-e5d06f3ef5aa4724ff385e18fd0a2ad69a5b1740bb092715bc1a5d9558927bb9">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>EmailConfig.java</strong><dd><code>Add Email configuration class for tenant-specific email settings</code></dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/tenant/EmailConfig.java
<li>Introduced <code>EmailConfig</code> class for tenant email settings.<br> <li> Contains host, port, SSL, template, and parameter fields.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-6d974788f3e05e74df451b403cdb27714d1365f93aeb49ef8daccb9ca482083b">+14/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>FbConfig.java</strong><dd><code>Add Facebook authentication configuration class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/tenant/FbConfig.java
<li>Added <code>FbConfig</code> class for Facebook authentication settings.<br> <li> Includes app ID and secret fields.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-7aaa7215f1c13b0eae5cb58e134e8e70b0687268de0fd3fe57339de6d15c69d7">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>GoogleConfig.java</strong><dd><code>Add Google authentication configuration class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/tenant/GoogleConfig.java
<li>Introduced <code>GoogleConfig</code> class for Google authentication settings.<br> <li> Contains client ID and secret fields.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-6065291e047e39ce3cce9f2f27ab594b01a5a01005ebee7fb18b93979526c587">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>OtpConfig.java</strong><dd><code>Add OTP configuration class for tenant-specific OTP settings</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/tenant/OtpConfig.java
<li>Added <code>OtpConfig</code> class for OTP-related tenant settings.<br> <li> Includes OTP length, try limits, resend controls, and whitelisted <br>inputs.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-efcf4feae79c7229b0d7d55e493a671654e658f747200e3874fdd71d969068dd">+15/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RsaKey.java</strong><dd><code>Add RSA key configuration class for token signing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/tenant/RsaKey.java
<li>Introduced <code>RsaKey</code> class for managing RSA key pairs.<br> <li> Contains public/private keys, key ID, and current flag.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-682e0a1f3776435242579529061fda76cde0252d188fbe42b5e18922fd4921b7">+11/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>SmsConfig.java</strong><dd><code>Add SMS configuration class for tenant-specific SMS settings</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/tenant/SmsConfig.java
<li>Added <code>SmsConfig</code> class for SMS sending configuration.<br> <li> Contains host, port, SSL, template, and parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-9fd1b139e5630d5803b4044e1cb7eec784402c25f8114d434044d8e4997d10a4">+14/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>TenantConfig.java</strong><dd><code>Add aggregate TenantConfig class for tenant settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/tenant/TenantConfig.java
<li>Introduced <code>TenantConfig</code> class as a builder for all tenant-level <br>configurations.<br> <li> Aggregates all tenant-specific config classes.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-205649932ac444118f522fd7bf5d81f833198257e47ff77bd47d180287cfc79d">+20/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>TokenConfig.java</strong><dd><code>Add Token configuration class for JWT and token settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/tenant/TokenConfig.java
<li>Added <code>TokenConfig</code> class for token-related settings.<br> <li> Includes algorithm, issuer, expiry times, claims, and RSA keys.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-3b8dda9a95199b290788208bbd77035a1fca435383d7e93e23ca8187d9444833">+15/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserConfig.java</strong><dd><code>Add User configuration class for user management endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/config/tenant/UserConfig.java
<li>Introduced <code>UserConfig</code> class for user management endpoints and <br>settings.<br> <li> Contains host, port, SSL, and user-related API paths.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-0db96768bd0369070a79bedc552e47f0f715309297af0da439fdf1ae4b7139b3">+14/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ConfigDao.java</strong><dd><code>Add DAO for fetching and assembling tenant configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dao/ConfigDao.java
<li>Added <code>ConfigDao</code> class for retrieving and assembling tenant <br>configuration from the database.<br> <li> Fetches and merges multiple config sources into a single <code>TenantConfig</code>.<br> <li> Uses RxJava for asynchronous operations and error handling.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-918f781f4876416d715b7f00979e527678a91b542a0d1c2c71fee7e2a1b34868">+112/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>PasswordlessDao.java</strong><dd><code>Add DAO for passwordless authentication state management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dao/PasswordlessDao.java
<li>Introduced <code>PasswordlessDao</code> for managing passwordless authentication <br>state in Redis.<br> <li> Supports get, set, and delete operations for passwordless models.<br> <li> Handles serialization/deserialization and expiry.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-d7fba46d45b250a6535586a5e33ddc56a3cba7f5a77812d55ee929f5c446177b">+53/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RefreshTokenDao.java</strong><dd><code>Add DAO for refresh token management in MySQL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dao/RefreshTokenDao.java
<li>Added <code>RefreshTokenDao</code> for managing refresh tokens in MySQL.<br> <li> Supports saving, validating, invalidating, and retrieving refresh <br>tokens.<br> <li> Handles error mapping and uses RxJava for async operations.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-a29e86025594bf0e2949398a2624d5cc8376201602583f5f06b001692369fec1">+79/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RevocationDao.java</strong><dd><code>Add DAO for managing token revocations in Redis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dao/RevocationDao.java
<li>Introduced <code>RevocationDao</code> for managing token revocations in Redis.<br> <li> Supports retrieving, adding, and removing expired refresh tokens in a <br>sorted set.<br> <li> Handles Redis request construction and response mapping.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-ec71b95965921cad1bd2b415b5acfeed7fe3d01c86d165465f95fa3b0c0ea6e9">+80/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>CodeModel.java</strong><dd><code>Add model for code-based authentication data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dao/model/CodeModel.java
<li>Added <code>CodeModel</code> class representing code-based authentication data.<br> <li> Includes code, user, meta info, and expiry fields.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-f6aa843d6fec19539c024086c7b796a65d60573bcde761e86be8fb2f657015cf">+19/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>PasswordlessModel.java</strong><dd><code>Add model for passwordless authentication state and logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dao/model/PasswordlessModel.java
<li>Introduced <code>PasswordlessModel</code> for representing passwordless <br>authentication state.<br> <li> Includes OTP, retry/resend logic, user info, and flow validation.<br> <li> Provides methods to increment retries and update resend state.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-2e183ca87ff9cea7530b585493d9cd4547d41fed6777fff2a5d7031d9d31abe3">+102/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RefreshTokenModel.java</strong><dd><code>Add model for refresh token data structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dao/model/RefreshTokenModel.java
<li>Added <code>RefreshTokenModel</code> class for representing refresh token data.<br> <li> Includes tenant, user, token, expiry, device, and source info.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-5f248063da82a075ade0fa7b7a4b27ca32c107dbfc64c422186bac50bb20e554">+17/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserDto.java</strong><dd><code>Add DTO for user data with extensible fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dto/UserDto.java
<li>Introduced <code>UserDto</code> class for user data transfer.<br> <li> Supports standard user fields and dynamic additional info with Jackson <br>annotations.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-a964c27482d0322d088891f24e9af519aaf50ae402db59a31924e493b3cc2e61">+40/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>V1AuthFbRequestDto.java</strong><dd><code>Add DTO for Facebook authentication request with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dto/request/V1AuthFbRequestDto.java
<li>Added <code>V1AuthFbRequestDto</code> for Facebook authentication requests.<br> <li> Includes access token, response type, flow, meta info, and additional <br>info.<br> <li> Provides validation logic for required fields and response types.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/8/files#diff-180450e469f7510ad04b65f2031c78dbae2449a5cef311e9f807eec2ed9f5909">+53/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></details></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
