### PR TITLE
chore: add code 3

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/Main.java
+++ b/src/main/java/com/dreamsportslabs/guardian/Main.java
@@ -1,0 +1,46 @@
+package com.dreamsportslabs.guardian;
+
+import com.dreamsportslabs.guardian.injection.GuiceInjector;
+import com.dreamsportslabs.guardian.injection.MainModule;
+import com.dreamsportslabs.guardian.utils.SharedDataUtils;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Launcher;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.impl.cpu.CpuCoreSensor;
+import java.util.List;
+
+public class Main extends Launcher {
+
+  public static void main(String[] args) {
+    Main launcher = new Main();
+    launcher.dispatch(args);
+  }
+
+  @Override
+  public void beforeStartingVertx(VertxOptions vertxOptions) {
+    vertxOptions
+        .setEventLoopPoolSize(this.getNumOfCores())
+        .setPreferNativeTransport(true)
+        .setWorkerPoolSize(10);
+  }
+
+  @Override
+  public void afterStartingVertx(Vertx vertx) {
+    this.initializeGuiceInjector(vertx);
+  }
+
+  @Override
+  public void beforeDeployingVerticle(DeploymentOptions deploymentOptions) {
+    deploymentOptions.setInstances(1);
+  }
+
+  private Integer getNumOfCores() {
+    return CpuCoreSensor.availableProcessors();
+  }
+
+  private void initializeGuiceInjector(Vertx vertx) {
+    GuiceInjector.initialize(List.of(new MainModule(vertx)));
+    SharedDataUtils.put(vertx, GuiceInjector.class);
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/constant/Channel.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/Channel.java
@@ -1,0 +1,15 @@
+package com.dreamsportslabs.guardian.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum Channel {
+  EMAIL("email"),
+  SMS("sms");
+
+  private final String name;
+
+  Channel(String name) {
+    this.name = name;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/constant/Constants.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/Constants.java
@@ -1,0 +1,81 @@
+package com.dreamsportslabs.guardian.constant;
+
+import com.google.common.collect.ImmutableList;
+import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
+
+public final class Constants {
+  public static final String TENANT_ID = "tenant-id";
+  public static final String USERID = "userId";
+
+  public static final String TOKEN = "token";
+  public static final String CODE = "code";
+
+  public static final String FACEBOOK = "facebook";
+  public static final String GOOGLE = "google";
+
+  public static final String EXPIRY_OPTION_REDIS = "EX";
+  public static final String STATIC_OTP_NUMBER = "9";
+
+  // Application config
+  public static final String PORT = "port";
+  public static final String MYSQL_WRITER_HOST = "mysql_writer_host";
+  public static final String MYSQL_READER_HOST = "mysql_reader_host";
+  public static final String MYSQL_DATABASE = "mysql_database";
+  public static final String MYSQL_USER = "mysql_user";
+  public static final String MYSQL_PASSWORD = "mysql_password";
+  public static final String MYSQL_WRITER_MAX_POOL_SIZE = "mysql_writer_max_pool_size";
+  public static final String MYSQL_READER_MAX_POOL_SIZE = "mysql_reader_max_pool_size";
+  public static final String REDIS_HOST = "redis_host";
+  public static final String REDIS_PORT = "redis_port";
+  public static final String REDIS_TYPE = "redis_type";
+  public static final String HTTP_CONNECT_TIMEOUT = "http_connect_timeout";
+  public static final String HTTP_READ_TIMEOUT = "http_read_timeout";
+  public static final String HTTP_WRITE_TIMEOUT = "http_write_timeout";
+  public static final String TENANT_CONFIG_REFRESH_INTERVAL = "tenant_config_refresh_interval";
+
+  // JWT CLAIMS
+  public static final String JWT_CLAIMS_ISS = "iss";
+  public static final String JWT_CLAIMS_SUB = "sub";
+  public static final String JWT_CLAIMS_IAT = "iat";
+  public static final String JWT_CLAIMS_EXP = "exp";
+  public static final String JWT_CLAIMS_RFT_ID = "rft_id";
+
+  public static final ImmutableList<String> fbAuthResponseTypes = ImmutableList.of(CODE, TOKEN);
+  public static final ImmutableList<String> passwordlessAuthResponseTypes =
+      ImmutableList.of(CODE, TOKEN);
+  public static final ImmutableList<String> registerResponseTypes = ImmutableList.of(CODE, TOKEN);
+  public static final ImmutableList<String> loginResponseTypes = ImmutableList.of(CODE, TOKEN);
+
+  public static final ArrayList<String> prohibitedForwardingHeaders = new ArrayList<>();
+
+  static {
+    prohibitedForwardingHeaders.add("CONTENT-LENGTH");
+    prohibitedForwardingHeaders.add("ACCEPT");
+    prohibitedForwardingHeaders.add("CONNECTION");
+    prohibitedForwardingHeaders.add("HOST");
+    prohibitedForwardingHeaders.add("CONTENT-TYPE");
+    prohibitedForwardingHeaders.add("USER-AGENT");
+    prohibitedForwardingHeaders.add("ACCEPT-ENCODING");
+  }
+
+  public static final String EMAIL = "email";
+  public static final String PHONE = "phoneNumber";
+
+  public static final String CACHE_KEY_CODE = "CODE";
+  public static final String CACHE_KEY_STATE = "STATE";
+
+  public static final String TOKEN_TYPE = "Bearer";
+
+  public static final JsonObject NO_PICTURE = new JsonObject().put("data", new JsonObject());
+
+  public static final String NEG_INF = "-inf";
+  public static final Integer REVOCATIONS_FLOOR_FACTOR = 10;
+  public static final Integer REVOCATIONS_FLOOR_FACTOR_2 = 60;
+  public static final String REVOCATIONS_KEY_SEPARATOR = "_";
+  public static final String REDIS_OPTION_BYSCORE = "BYSCORE";
+  public static final Integer REVOCATIONS_KEY_APPLICATION_ID_INDEX = 0;
+  public static final Integer REVOCATIONS_KEY_SCORE_START_INDEX = 1;
+  public static final Integer REVOCATIONS_KEY_SCORE_END_INDEX = 2;
+  public static final String REVOCATIONS_REDIS_KEY_PREFIX = "revocations";
+}

--- a/src/main/java/com/dreamsportslabs/guardian/constant/Contact.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/Contact.java
@@ -1,0 +1,22 @@
+package com.dreamsportslabs.guardian.constant;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class Contact {
+  private Channel channel;
+  private String identifier;
+  private Template template;
+
+  public boolean validate() {
+    if (identifier == null || channel == null) {
+      return false;
+    }
+
+    return template == null || template.validate();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/constant/Flow.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/Flow.java
@@ -1,0 +1,16 @@
+package com.dreamsportslabs.guardian.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum Flow {
+  SIGNINUP("signinup"),
+  SIGNIN("signin"),
+  SIGNUP("signup");
+
+  private final String flow;
+
+  Flow(String flow) {
+    this.flow = flow;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/constant/ResponseType.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/ResponseType.java
@@ -1,0 +1,15 @@
+package com.dreamsportslabs.guardian.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum ResponseType {
+  CODE("code"),
+  TOKEN("token");
+
+  private final String responseType;
+
+  ResponseType(String responseType) {
+    this.responseType = responseType;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/constant/Template.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/Template.java
@@ -1,0 +1,21 @@
+package com.dreamsportslabs.guardian.constant;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Template {
+  private String name;
+  private Map<String, String> params;
+
+  public boolean validate() {
+    return !StringUtils.isBlank(this.name);
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/CodeDao.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/CodeDao.java
@@ -1,0 +1,51 @@
+package com.dreamsportslabs.guardian.dao;
+
+import static com.dreamsportslabs.guardian.constant.Constants.CACHE_KEY_CODE;
+import static com.dreamsportslabs.guardian.constant.Constants.EXPIRY_OPTION_REDIS;
+
+import com.dreamsportslabs.guardian.dao.model.CodeModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+import io.vertx.rxjava3.redis.client.Command;
+import io.vertx.rxjava3.redis.client.Redis;
+import io.vertx.rxjava3.redis.client.Request;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class CodeDao {
+  private final Redis redisClient;
+  private final ObjectMapper objectMapper;
+
+  @SneakyThrows
+  public Completable saveCode(CodeModel model, String tenantId) {
+    return redisClient
+        .rxSend(
+            Request.cmd(Command.SET)
+                .arg(getCacheKey(model.getCode(), tenantId))
+                .arg(objectMapper.writeValueAsString(model))
+                .arg(EXPIRY_OPTION_REDIS)
+                .arg(model.getExpiry()))
+        .ignoreElement();
+  }
+
+  public Maybe<CodeModel> getCode(String code, String tenantId) {
+    return redisClient
+        .rxSend(Request.cmd(Command.GET).arg(getCacheKey(code, tenantId)))
+        .map(response -> objectMapper.readValue(response.toString(), CodeModel.class));
+  }
+
+  public Completable deleteCode(String code, String tenantId) {
+    return redisClient
+        .rxSend(Request.cmd(Command.DEL).arg(getCacheKey(code, tenantId)))
+        .ignoreElement();
+  }
+
+  private String getCacheKey(String code, String tenantId) {
+    return CACHE_KEY_CODE + "_" + tenantId + "_" + code;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/query/ConfigQuery.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/query/ConfigQuery.java
@@ -1,0 +1,91 @@
+package com.dreamsportslabs.guardian.dao.query;
+
+public class ConfigQuery {
+  public static final String SMS_CONFIG =
+      """
+    SELECT is_ssl_enabled,
+           host,
+           port,
+           send_sms_path,
+           template_name,
+           template_params
+    FROM sms_config
+    WHERE tenant_id = ?
+    """;
+
+  public static final String AUTH_CODE_CONFIG =
+      """
+    SELECT tenant_id,
+           ttl,
+           length
+    FROM auth_code_config
+    WHERE tenant_id = ?
+    """;
+
+  public static final String USER_CONFIG =
+      """
+    SELECT is_ssl_enabled,
+           host,
+           port,
+           get_user_path,
+           create_user_path,
+           authenticate_user_path,
+           add_provider_path
+    FROM user_config
+    WHERE tenant_id = ?
+    """;
+
+  public static final String EMAIL_CONFIG =
+      """
+    SELECT is_ssl_enabled,
+           host,
+           port,
+           send_email_path,
+           template_name,
+           template_params
+    FROM email_config
+    WHERE tenant_id = ?
+    """;
+
+  public static final String FB_AUTH_CONFIG =
+      """
+    SELECT app_id,
+           app_secret
+    FROM fb_config
+    WHERE tenant_id = ?
+    """;
+
+  public static final String GOOGLE_AUTH_CONFIG =
+      """
+        SELECT client_id,
+               client_secret
+        FROM google_config
+        WHERE tenant_id = ?
+        """;
+
+  public static final String TOKEN_CONFIG =
+      """
+    SELECT algorithm,
+           issuer,
+           access_token_expiry,
+           refresh_token_expiry,
+           id_token_expiry,
+           id_token_claims,
+           rsa_keys
+    FROM token_config
+    WHERE tenant_id = ?
+    """;
+
+  public static final String OTP_CONFIG =
+      """
+    SELECT otp_length,
+           try_limit,
+           is_otp_mocked,
+           resend_limit,
+           otp_resend_interval,
+           otp_validity,
+           whitelisted_inputs
+    FROM otp_config
+    WHERE tenant_id = ?
+    """;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/query/RefreshTokenSql.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/query/RefreshTokenSql.java
@@ -1,0 +1,18 @@
+package com.dreamsportslabs.guardian.dao.query;
+
+public class RefreshTokenSql {
+  public static final String SAVE_REFRESH_TOKEN =
+      "INSERT INTO refresh_tokens (tenant_id, user_id, refresh_token, refresh_token_exp, source, device_name, location, ip) VALUES (?, ?, ?, ?, ?, ?, ?, INET6_ATON(?))";
+
+  public static final String VALIDATE_REFRESH_TOKEN =
+      "SELECT user_id FROM refresh_tokens WHERE tenant_id = ? AND refresh_token = ? AND is_active = 1 AND refresh_token_exp > UNIX_TIMESTAMP()";
+
+  public static final String GET_ALL_REFRESH_TOKENS_FOR_USER =
+      "SELECT refresh_token AS refreshToken FROM refresh_tokens WHERE tenant_id = ? AND user_id = ? AND is_active = 1";
+
+  public static final String INVALIDATE_REFRESH_TOKEN =
+      "UPDATE refresh_tokens SET is_active = 0 WHERE tenant_id = ? AND refresh_token = ?";
+
+  public static final String INVALIDATE_ALL_REFRESH_TOKENS_FOR_USER =
+      "UPDATE refresh_tokens SET is_active = 0 WHERE tenant_id = ? AND user_id = ?";
+}

--- a/src/main/java/com/dreamsportslabs/guardian/filter/ConfigFilter.java
+++ b/src/main/java/com/dreamsportslabs/guardian/filter/ConfigFilter.java
@@ -1,0 +1,58 @@
+package com.dreamsportslabs.guardian.filter;
+
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.UNAUTHORIZED;
+
+import com.dreamsportslabs.guardian.cache.TenantCache;
+import com.dreamsportslabs.guardian.constant.Constants;
+import com.dreamsportslabs.guardian.injection.GuiceInjector;
+import com.dreamsportslabs.guardian.registry.Registry;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.ext.Provider;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.resteasy.core.interception.jaxrs.SuspendableContainerRequestContext;
+
+@PreMatching
+@Priority(1)
+@Slf4j
+@Provider
+public class ConfigFilter implements ContainerRequestFilter {
+  final Registry registry;
+  final TenantCache tenantCache;
+
+  public ConfigFilter() {
+    registry = GuiceInjector.getGuiceInjector().getInstance(Registry.class);
+    tenantCache = GuiceInjector.getGuiceInjector().getInstance(TenantCache.class);
+  }
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) {
+    // Todo: create a filter annotation instead of filtering out routes here, @Config
+    String path = requestContext.getUriInfo().getPath();
+    if (path.equalsIgnoreCase("/healthcheck")) {
+      return;
+    }
+
+    String tenantId = requestContext.getHeaderString(Constants.TENANT_ID);
+
+    if (StringUtils.isBlank(tenantId)) {
+      throw UNAUTHORIZED.getException();
+    }
+
+    SuspendableContainerRequestContext suspendableContext =
+        (SuspendableContainerRequestContext) requestContext;
+    suspendableContext.suspend();
+
+    tenantCache
+        .getTenantConfig(tenantId)
+        .subscribe(
+            r -> suspendableContext.resume(),
+            err -> {
+              log.error("Error Initializing tenant details", err);
+              suspendableContext.resume(err);
+            });
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/injection/GuiceInjector.java
+++ b/src/main/java/com/dreamsportslabs/guardian/injection/GuiceInjector.java
@@ -1,0 +1,38 @@
+package com.dreamsportslabs.guardian.injection;
+
+import com.dream11.rest.ClassInjector;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import java.util.List;
+import java.util.Objects;
+
+public class GuiceInjector implements ClassInjector {
+  private static GuiceInjector guiceInjector;
+  private final Injector injector;
+
+  private GuiceInjector(List<Module> modules) {
+    injector = Guice.createInjector(modules);
+  }
+
+  public static synchronized void initialize(List<Module> modules) {
+    if (guiceInjector != null) {
+      throw new IllegalStateException("GuiceInjector is already initialised");
+    } else {
+      guiceInjector = new GuiceInjector(modules);
+    }
+  }
+
+  public static GuiceInjector getGuiceInjector() {
+    if (guiceInjector == null) {
+      throw new IllegalStateException("GuiceInjector not initialised");
+    }
+    return guiceInjector;
+  }
+
+  @Override
+  public <T> T getInstance(Class<T> clazz) {
+    Objects.requireNonNull(injector, "injector is null, initialize first");
+    return injector.getInstance(clazz);
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/injection/MainModule.java
+++ b/src/main/java/com/dreamsportslabs/guardian/injection/MainModule.java
@@ -1,0 +1,31 @@
+package com.dreamsportslabs.guardian.injection;
+
+import com.dreamsportslabs.guardian.cache.TenantCache;
+import com.dreamsportslabs.guardian.client.MysqlClient;
+import com.dreamsportslabs.guardian.client.impl.MysqlClientImpl;
+import com.dreamsportslabs.guardian.registry.Registry;
+import com.dreamsportslabs.guardian.utils.SharedDataUtils;
+import com.google.inject.AbstractModule;
+import io.vertx.core.Vertx;
+import io.vertx.rxjava3.ext.web.client.WebClient;
+import io.vertx.rxjava3.redis.client.Redis;
+
+public class MainModule extends AbstractModule {
+  private final Vertx vertx;
+
+  public MainModule(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  @Override
+  protected void configure() {
+    bind(Vertx.class).toInstance(this.vertx);
+    bind(io.vertx.rxjava3.core.Vertx.class)
+        .toInstance(io.vertx.rxjava3.core.Vertx.newInstance(vertx));
+    bind(MysqlClient.class).toProvider(() -> SharedDataUtils.get(vertx, MysqlClientImpl.class));
+    bind(Redis.class).toProvider(() -> SharedDataUtils.get(vertx, Redis.class));
+    bind(WebClient.class).toProvider(() -> SharedDataUtils.get(vertx, WebClient.class));
+    bind(Registry.class).toProvider(() -> SharedDataUtils.get(vertx, Registry.class));
+    bind(TenantCache.class).toProvider(() -> SharedDataUtils.get(vertx, TenantCache.class));
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/registry/Registry.java
+++ b/src/main/java/com/dreamsportslabs/guardian/registry/Registry.java
@@ -1,0 +1,39 @@
+package com.dreamsportslabs.guardian.registry;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.keyvalue.MultiKey;
+
+@Slf4j
+public class Registry {
+  private final Map<MultiKey, Object> classMap;
+
+  private static final String DEFAULT_NAME = "default";
+
+  public Registry() {
+    this.classMap = new HashMap<>();
+  }
+
+  public <T> T get(String tenant, Class<T> clazz) {
+    return this.get(tenant, clazz, DEFAULT_NAME);
+  }
+
+  public <T> T get(String tenant, Class<T> clazz, String name) {
+    return (T) classMap.get(getKey(clazz, tenant, name));
+  }
+
+  public <T> void put(String tenant, T object) {
+    this.put(tenant, object, DEFAULT_NAME);
+  }
+
+  public <T> void put(String tenant, T object, String name) {
+    Objects.requireNonNull(object);
+    classMap.put(getKey(object.getClass(), tenant, name), object);
+  }
+
+  private MultiKey getKey(Class<?> clazz, String tenant, String name) {
+    return new MultiKey(tenant, clazz.getName(), name);
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/registry/RegistryInit.java
+++ b/src/main/java/com/dreamsportslabs/guardian/registry/RegistryInit.java
@@ -1,0 +1,33 @@
+package com.dreamsportslabs.guardian.registry;
+
+import com.dreamsportslabs.guardian.config.tenant.RsaKey;
+import com.dreamsportslabs.guardian.config.tenant.TenantConfig;
+import com.dreamsportslabs.guardian.config.tenant.TokenConfig;
+import com.dreamsportslabs.guardian.service.impl.idproviders.FacebookIdProvider;
+import com.dreamsportslabs.guardian.service.impl.idproviders.GoogleIdProvider;
+import io.fusionauth.jwt.Signer;
+import io.fusionauth.jwt.rsa.RSASigner;
+import lombok.SneakyThrows;
+
+public class RegistryInit {
+
+  @SneakyThrows
+  public static TenantConfig initializeRegistry(Registry registry, TenantConfig tenantConfig) {
+    String tenantId = tenantConfig.getTenantId();
+    registry.put(tenantId, tenantConfig);
+    registry.put(tenantId, getTokenSigner(tenantConfig.getTokenConfig()));
+    registry.put(tenantId, new FacebookIdProvider(tenantConfig.getFbConfig()));
+    registry.put(tenantId, new GoogleIdProvider(tenantConfig.getGoogleConfig()));
+    return tenantConfig;
+  }
+
+  private static Signer getTokenSigner(TokenConfig config) {
+    RsaKey currentKey = config.getRsaKeys().stream().filter(RsaKey::getCurrent).toList().get(0);
+    if ("RS512".equals(config.getAlgorithm())) {
+      return RSASigner.newSHA512Signer(currentKey.getPrivateKey(), currentKey.getKid());
+    } else if ("RS256".equals(config.getAlgorithm())) {
+      return RSASigner.newSHA256Signer(currentKey.getPrivateKey(), currentKey.getKid());
+    }
+    throw new Error("Invalid configuration, only RS256 and RS512 are supported");
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/AuthorizationService.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/AuthorizationService.java
@@ -1,0 +1,192 @@
+package com.dreamsportslabs.guardian.service;
+
+import static com.dreamsportslabs.guardian.constant.Constants.CODE;
+import static com.dreamsportslabs.guardian.constant.Constants.TOKEN;
+import static com.dreamsportslabs.guardian.constant.Constants.TOKEN_TYPE;
+import static com.dreamsportslabs.guardian.constant.Constants.USERID;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_CODE;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_REQUEST;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.UNAUTHORIZED;
+
+import com.dreamsportslabs.guardian.config.tenant.AuthCodeConfig;
+import com.dreamsportslabs.guardian.config.tenant.TenantConfig;
+import com.dreamsportslabs.guardian.config.tenant.TokenConfig;
+import com.dreamsportslabs.guardian.dao.CodeDao;
+import com.dreamsportslabs.guardian.dao.RefreshTokenDao;
+import com.dreamsportslabs.guardian.dao.RevocationDao;
+import com.dreamsportslabs.guardian.dao.model.CodeModel;
+import com.dreamsportslabs.guardian.dao.model.RefreshTokenModel;
+import com.dreamsportslabs.guardian.dto.request.MetaInfo;
+import com.dreamsportslabs.guardian.dto.request.V1CodeTokenExchangeRequestDto;
+import com.dreamsportslabs.guardian.dto.request.V1LogoutRequestDto;
+import com.dreamsportslabs.guardian.dto.request.V1RefreshTokenRequestDto;
+import com.dreamsportslabs.guardian.dto.response.CodeResponseDto;
+import com.dreamsportslabs.guardian.dto.response.RefreshTokenResponseDto;
+import com.dreamsportslabs.guardian.dto.response.TokenResponseDto;
+import com.dreamsportslabs.guardian.registry.Registry;
+import com.dreamsportslabs.guardian.utils.Utils;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class AuthorizationService {
+  private final Registry registry;
+  private final TokenIssuer tokenIssuer;
+
+  private final RefreshTokenDao refreshTokenDao;
+  private final CodeDao codeDao;
+  private final RevocationDao revocationDao;
+
+  public Single<Object> generate(
+      JsonObject user, String responseType, MetaInfo metaInfo, String tenantId) {
+    if (responseType.equals(TOKEN)) {
+      return generateTokens(user, metaInfo, tenantId).map(res -> res);
+    } else if (responseType.equals(CODE)) {
+      return generateCode(user, metaInfo, tenantId).map(res -> res);
+    }
+    throw INVALID_REQUEST.getException();
+  }
+
+  private Single<TokenResponseDto> generateTokens(
+      JsonObject user, MetaInfo metaInfo, String tenantId) {
+    TenantConfig config = registry.get(tenantId, TenantConfig.class);
+    String refreshToken = tokenIssuer.generateRefreshToken();
+    Long iat = System.currentTimeMillis() / 1000;
+    return Single.zip(
+            tokenIssuer.generateAccessToken(
+                user.getString(USERID), iat, getRftId(refreshToken), config),
+            tokenIssuer.generateIdToken(user, iat, config),
+            (accessToken, idToken) ->
+                new TokenResponseDto(
+                    accessToken,
+                    refreshToken,
+                    idToken,
+                    TOKEN_TYPE,
+                    config.getTokenConfig().getAccessTokenExpiry(),
+                    user.getBoolean("isNewUser", false)))
+        .flatMap(
+            dto ->
+                refreshTokenDao
+                    .saveRefreshToken(getRefreshTokenDto(refreshToken, user, iat, metaInfo, config))
+                    .andThen(Single.just(dto)));
+  }
+
+  private RefreshTokenModel getRefreshTokenDto(
+      String refreshToken, JsonObject user, Long iat, MetaInfo metaInfo, TenantConfig config) {
+    return RefreshTokenModel.builder()
+        .tenantId(config.getTenantId())
+        .userId(user.getString(USERID))
+        .refreshToken(refreshToken)
+        .refreshTokenExp(iat + config.getTokenConfig().getRefreshTokenExpiry())
+        .deviceName(metaInfo.getDeviceName())
+        .ip(metaInfo.getIp())
+        .location(metaInfo.getLocation())
+        .source(metaInfo.getSource())
+        .build();
+  }
+
+  public Single<RefreshTokenResponseDto> refreshTokens(
+      V1RefreshTokenRequestDto dto, String tenantId) {
+    TenantConfig config = registry.get(tenantId, TenantConfig.class);
+    return refreshTokenDao
+        .getRefreshToken(dto.getRefreshToken(), tenantId)
+        .switchIfEmpty(Single.error(UNAUTHORIZED.getCustomException("Invalid refresh token")))
+        .flatMap(
+            userId ->
+                tokenIssuer.generateAccessToken(
+                    userId,
+                    System.currentTimeMillis() / 1000,
+                    getRftId(dto.getRefreshToken()),
+                    config))
+        .map(
+            accessToken ->
+                new RefreshTokenResponseDto(
+                    accessToken, TOKEN_TYPE, config.getTokenConfig().getAccessTokenExpiry()));
+  }
+
+  private String getRftId(String refreshToken) {
+    return Utils.getMd5Hash(refreshToken);
+  }
+
+  private Single<CodeResponseDto> generateCode(
+      JsonObject user, MetaInfo metaInfo, String tenantId) {
+    AuthCodeConfig config = registry.get(tenantId, TenantConfig.class).getAuthCodeConfig();
+    String code = RandomStringUtils.randomAlphanumeric(config.getLength());
+    CodeModel codeModel =
+        CodeModel.builder()
+            .user(user.getMap())
+            .code(code)
+            .metaInfo(metaInfo)
+            .expiry(config.getTtl())
+            .build();
+    return codeDao
+        .saveCode(codeModel, tenantId)
+        .andThen(Single.just(new CodeResponseDto(code, config.getTtl())));
+  }
+
+  public Single<TokenResponseDto> codeTokenExchange(
+      V1CodeTokenExchangeRequestDto dto, String tenantId) {
+    return codeDao
+        .getCode(dto.getCode(), tenantId)
+        .switchIfEmpty(Single.error(INVALID_CODE.getException()))
+        .flatMap(
+            model -> generateTokens(new JsonObject(model.getUser()), model.getMetaInfo(), tenantId))
+        .doOnSuccess(res -> codeDao.deleteCode(dto.getCode(), tenantId).subscribe());
+  }
+
+  public Completable logout(V1LogoutRequestDto requestDto, String tenantId) {
+    return invalidateRefreshToken(requestDto, tenantId);
+  }
+
+  private Completable invalidateRefreshToken(V1LogoutRequestDto dto, String tenantId) {
+    return refreshTokenDao
+        .getRefreshToken(dto.getRefreshToken(), tenantId)
+        .switchIfEmpty(Single.error(UNAUTHORIZED.getCustomException("Invalid refresh token")))
+        .flatMapCompletable(
+            userId -> {
+              if (dto.getIsUniversalLogout()) {
+                return refreshTokenDao
+                    .getRefreshTokens(userId, tenantId)
+                    .flatMap(
+                        list ->
+                            refreshTokenDao
+                                .invalidateAllRefreshTokensForUser(userId, tenantId)
+                                .andThen(Single.just(list)))
+                    .doOnSuccess(tokens -> updateRevocations(tokens, tenantId))
+                    .ignoreElement();
+              } else {
+                return refreshTokenDao
+                    .invalidateRefreshToken(dto.getRefreshToken(), tenantId)
+                    .doOnComplete(
+                        () -> updateRevocations(List.of(dto.getRefreshToken()), tenantId));
+              }
+            });
+  }
+
+  private void updateRevocations(List<String> refreshTokens, String tenantId) {
+    TokenConfig config = registry.get(tenantId, TenantConfig.class).getTokenConfig();
+    List<String> expiredRefreshTokens = new ArrayList<>();
+
+    for (String refreshToken : refreshTokens) {
+      String rftId = getRftId(refreshToken);
+      expiredRefreshTokens.add(rftId);
+    }
+    long currentTimeStamp = System.currentTimeMillis() / 1000;
+
+    long accessTokenExpiry = config.getAccessTokenExpiry() * 60;
+
+    revocationDao.addExpiredRefreshTokensInSortedSet(
+        currentTimeStamp, expiredRefreshTokens, tenantId);
+
+    revocationDao.removeExpiredRefreshTokensFromSortedSet(
+        currentTimeStamp, accessTokenExpiry, tenantId);
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/impl/idproviders/FacebookIdProvider.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/impl/idproviders/FacebookIdProvider.java
@@ -1,0 +1,57 @@
+package com.dreamsportslabs.guardian.service.impl.idproviders;
+
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INTERNAL_SERVER_ERROR;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_REQUEST;
+
+import com.dreamsportslabs.guardian.config.tenant.FbConfig;
+import com.dreamsportslabs.guardian.injection.GuiceInjector;
+import com.dreamsportslabs.guardian.service.IdProvider;
+import com.google.common.hash.Hashing;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.ext.web.client.WebClient;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+public class FacebookIdProvider implements IdProvider {
+  private final WebClient webClient;
+  private final String appSecret;
+  private final String fields = "id,name,first_name,middle_name,last_name,email,picture";
+
+  public FacebookIdProvider(FbConfig fbConfigDto) {
+    this.webClient = GuiceInjector.getGuiceInjector().getInstance(WebClient.class);
+    this.appSecret = fbConfigDto.getAppSecret();
+  }
+
+  @Override
+  public Single<JsonObject> getUserIdentity(String accessToken) {
+    String appSecret =
+        Hashing.hmacSha256(this.appSecret.getBytes())
+            .hashString(accessToken, StandardCharsets.UTF_8)
+            .toString();
+    return webClient
+        .get(443, "graph.facebook.com", "/me")
+        .ssl(true)
+        .addQueryParam("access_token", accessToken)
+        .addQueryParam("appsecret_proof", appSecret)
+        .addQueryParam("fields", this.fields)
+        .rxSend()
+        .map(
+            res -> {
+              if (res.statusCode() == 200) {
+                JsonObject jsonBody = res.bodyAsJsonObject();
+                if (StringUtils.isNotBlank(jsonBody.getString("email"))) {
+                  return jsonBody;
+                } else {
+                  throw INVALID_REQUEST.getCustomException("Email unavailable");
+                }
+              } else if (res.statusCode() == 400) {
+                throw INVALID_REQUEST.getCustomException("Invalid access token");
+              } else {
+                throw INTERNAL_SERVER_ERROR.getException();
+              }
+            });
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/impl/idproviders/GoogleIdProvider.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/impl/idproviders/GoogleIdProvider.java
@@ -1,0 +1,50 @@
+package com.dreamsportslabs.guardian.service.impl.idproviders;
+
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_REQUEST;
+
+import com.dreamsportslabs.guardian.config.tenant.GoogleConfig;
+import com.dreamsportslabs.guardian.service.IdProvider;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+import java.util.Collections;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GoogleIdProvider implements IdProvider {
+  private final GoogleIdTokenVerifier verifier;
+
+  public GoogleIdProvider(GoogleConfig config) throws GeneralSecurityException, IOException {
+    verifier =
+        new GoogleIdTokenVerifier.Builder(
+                GoogleNetHttpTransport.newTrustedTransport(), GsonFactory.getDefaultInstance())
+            .setAudience(Collections.singletonList(config.getClientId()))
+            .build();
+  }
+
+  @Override
+  public Single<JsonObject> getUserIdentity(String idTokenString) {
+    GoogleIdToken idToken;
+
+    try {
+      idToken = verifier.verify(idTokenString);
+    } catch (Exception e) {
+      throw INVALID_REQUEST.getCustomException("Invalid id token");
+    }
+
+    if (idToken == null) {
+      throw INVALID_REQUEST.getCustomException("Invalid id token");
+    }
+
+    String[] parts = idTokenString.split("\\.");
+    String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]));
+
+    return Single.just(new JsonObject(payloadJson));
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/utils/ConfigUtil.java
+++ b/src/main/java/com/dreamsportslabs/guardian/utils/ConfigUtil.java
@@ -1,0 +1,29 @@
+package com.dreamsportslabs.guardian.utils;
+
+import io.vertx.config.ConfigRetrieverOptions;
+import io.vertx.config.ConfigStoreOptions;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.config.ConfigRetriever;
+import io.vertx.rxjava3.core.Vertx;
+
+public final class ConfigUtil {
+  private ConfigUtil() {
+    throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+  }
+
+  public static ConfigRetriever getConfigRetriever(Vertx vertx) {
+    ConfigStoreOptions defaultConfig =
+        new ConfigStoreOptions()
+            .setType("file")
+            .setFormat("hocon")
+            .setConfig(new JsonObject().put("path", "guardian-default.conf"));
+    ConfigStoreOptions envConfig =
+        new ConfigStoreOptions()
+            .setType("file")
+            .setFormat("hocon")
+            .setConfig(new JsonObject().put("path", "guardian.conf"));
+
+    return ConfigRetriever.create(
+        vertx, new ConfigRetrieverOptions().addStore(defaultConfig).addStore(envConfig));
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/utils/JsonUtils.java
+++ b/src/main/java/com/dreamsportslabs/guardian/utils/JsonUtils.java
@@ -1,0 +1,61 @@
+package com.dreamsportslabs.guardian.utils;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.sqlclient.Row;
+import io.vertx.rxjava3.sqlclient.RowSet;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class JsonUtils {
+
+  private JsonUtils() {
+    throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+  }
+
+  private static final ObjectMapper snakeCaseObjectMapper =
+      JsonMapper.builder()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+          .serializationInclusion(JsonInclude.Include.NON_NULL)
+          .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+          .build();
+
+  public static JsonObject getJsonObjectFromNestedJson(JsonObject json, String flattenedKey) {
+    JsonObject cur = json;
+    String[] keys = flattenedKey.split("\\.");
+    for (String key : keys) {
+      if (!cur.containsKey(key)) {
+        return new JsonObject();
+      }
+      cur = cur.getJsonObject(key);
+    }
+    return cur;
+  }
+
+  @SneakyThrows
+  public static <T> List<T> rowSetToList(RowSet<Row> rows, Class<T> clazz) {
+    List<T> list = new ArrayList<>();
+
+    if (rows.columnsNames().size() == 1) {
+      String columnName = rows.columnsNames().get(0);
+      for (Row row : rows) {
+        list.add((T) row.getValue(columnName));
+      }
+      return list;
+    }
+
+    for (Row row : rows) {
+      list.add(snakeCaseObjectMapper.readValue(row.toJson().toString(), clazz));
+    }
+    return list;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/utils/SharedDataUtils.java
+++ b/src/main/java/com/dreamsportslabs/guardian/utils/SharedDataUtils.java
@@ -1,0 +1,66 @@
+package com.dreamsportslabs.guardian.utils;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.LocalMap;
+import io.vertx.core.shareddata.Shareable;
+import java.util.NoSuchElementException;
+import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.keyvalue.MultiKey;
+
+@Slf4j
+public final class SharedDataUtils {
+  private static final String SHARED_DATA = "sharedData";
+  private static final String DEFAULT_NAME = "default";
+
+  private SharedDataUtils() {
+    throw new UnsupportedOperationException("Utility class cannot be instantiated");
+  }
+
+  /**
+   * Returns a singleton shared object across vert.x instance Note: It is your responsibility to
+   * ensure T returned by supplier is thread-safe
+   */
+  public static <T> T getOrCreateInstance(Vertx vertx, MultiKey key, Supplier<T> supplier) {
+    LocalMap<MultiKey, ThreadSafe<T>> sharedDataMap = vertx.sharedData().getLocalMap(SHARED_DATA);
+    return sharedDataMap.computeIfAbsent(key, k -> new ThreadSafe<>(supplier.get())).object();
+  }
+
+  /**
+   * Helper wrapper on getOrCreate to setInstance. Note: Doesn't reset the instance if already
+   * exists
+   */
+  public static <T> void put(Vertx vertx, T instance) {
+    put(vertx, instance, DEFAULT_NAME);
+  }
+
+  /**
+   * Helper wrapper on getOrCreate to setInstance. Note: Doesn't reset the instance if already
+   * exists
+   */
+  public static <T> void put(Vertx vertx, T instance, String name) {
+    getOrCreateInstance(vertx, getKey(instance.getClass(), name), () -> instance);
+  }
+
+  /** Helper wrapper on getOrCreate to getInstance. */
+  public static <T> T get(Vertx vertx, Class<T> clazz) {
+    return get(vertx, clazz, DEFAULT_NAME);
+  }
+
+  /** Helper wrapper on getOrCreate to getInstance. */
+  public static <T> T get(Vertx vertx, Class<T> clazz, String name) {
+    return getOrCreateInstance(
+        vertx,
+        getKey(clazz, name),
+        () -> {
+          throw new NoSuchElementException("Cannot find default instance of " + clazz.getName());
+        });
+  }
+
+  record ThreadSafe<T>(@Getter T object) implements Shareable {}
+
+  private static MultiKey getKey(Class<?> clazz, String name) {
+    return new MultiKey(clazz.getName(), name);
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/utils/Utils.java
+++ b/src/main/java/com/dreamsportslabs/guardian/utils/Utils.java
@@ -1,0 +1,40 @@
+package com.dreamsportslabs.guardian.utils;
+
+import static com.dreamsportslabs.guardian.constant.Constants.prohibitedForwardingHeaders;
+
+import io.vertx.rxjava3.core.MultiMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.regex.Pattern;
+import org.apache.commons.codec.digest.DigestUtils;
+
+public final class Utils {
+
+  private Utils() {
+    throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+  }
+
+  // TODO: revalidate the regex
+  public static boolean validateEmail(String email) {
+    return Pattern.compile("^(.+)@(\\S+)$").matcher(email).matches();
+  }
+
+  // TODO: revalidate the regex
+  public static boolean validateMobileNumber(String mobile) {
+    // Should have 7 to 15 numbers and may or may not include internation code with + sign
+    return Pattern.compile("^\\+?[0-9]{7,15}$").matcher(mobile).matches();
+  }
+
+  public static MultiMap getForwardingHeaders(MultivaluedMap<String, String> headers) {
+    MultiMap forwardingHeaders = MultiMap.caseInsensitiveMultiMap();
+    for (String key : headers.keySet()) {
+      if (!prohibitedForwardingHeaders.contains(key.toUpperCase())) {
+        forwardingHeaders.add(key, headers.getFirst(key));
+      }
+    }
+    return forwardingHeaders;
+  }
+
+  public static String getMd5Hash(String input) {
+    return DigestUtils.md5Hex(input).toUpperCase();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/utils/VertxUtil.java
+++ b/src/main/java/com/dreamsportslabs/guardian/utils/VertxUtil.java
@@ -1,0 +1,92 @@
+package com.dreamsportslabs.guardian.utils;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.shareddata.LocalMap;
+import io.vertx.core.shareddata.Shareable;
+import java.util.NoSuchElementException;
+import java.util.function.Supplier;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class VertxUtil {
+
+  private static final String SHARED_DATA_MAP_NAME = "__vertx.sharedDataUtils";
+  private static final String CLASS_PREFIX = "__class.";
+  private static final String SHARED_DATA_DEFAULT_KEY = "__default.";
+
+  private static final String CONTEXT_INSTANCE_PREFIX = "__vertx.contextUtils.";
+
+  private VertxUtil() {
+    throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+  }
+
+  /**
+   * Returns a singleton shared object across vert.x instance Note: It is your responsibility to
+   * ensure T returned by supplier is thread-safe
+   */
+  public static <T> T getOrCreateSharedData(Vertx vertx, String name, Supplier<T> supplier) {
+    LocalMap<String, ThreadSafe<T>> singletons =
+        vertx.sharedData().getLocalMap(SHARED_DATA_MAP_NAME);
+    // LocalMap is internally backed by a ConcurrentMap
+    return singletons.computeIfAbsent(name, k -> new ThreadSafe<>(supplier.get())).object();
+  }
+
+  /**
+   * Helper wrapper on getOrCreate to setInstance. Note: Doesn't reset the instance if already
+   * exists
+   */
+  public static <T> void setInstanceInSharedData(Vertx vertx, T instance) {
+    setInstanceInSharedData(vertx, instance, SHARED_DATA_DEFAULT_KEY);
+  }
+
+  /**
+   * Helper wrapper on getOrCreate to setInstance. Note: Doesn't reset the instance if already
+   * exists
+   */
+  public static <T> void setInstanceInSharedData(Vertx vertx, T instance, String key) {
+    log.debug(
+        "setInstanceInSharedData: vertx instance {} is setting type : {} for instance: {}  in key {}",
+        System.identityHashCode(vertx),
+        instance.getClass().getName(),
+        System.identityHashCode(instance),
+        key);
+    getOrCreateSharedData(
+        vertx, CLASS_PREFIX + instance.getClass().getName() + key, () -> instance);
+  }
+
+  /** Helper wrapper on getOrCreate to getInstance. */
+  public static <T> T getInstanceFromSharedData(Vertx vertx, Class<T> clazz) {
+    return getInstanceFromSharedData(vertx, clazz, SHARED_DATA_DEFAULT_KEY);
+  }
+
+  /** Helper wrapper on getOrCreate to getInstance. */
+  public static <T> T getInstanceFromSharedData(Vertx vertx, Class<T> clazz, String key) {
+    log.debug(
+        "getInstanceFromSharedData: vertx instance {} is getting type : {}  in key {}",
+        System.identityHashCode(vertx),
+        clazz.getName(),
+        key);
+    return getOrCreateSharedData(
+        vertx,
+        CLASS_PREFIX + clazz.getName() + key,
+        () -> {
+          throw new NoSuchElementException("Cannot find default instance of " + clazz.getName());
+        });
+  }
+
+  /**
+   * Accessible from anywhere in this verticle instance. Note: This has to be set from one of the
+   * VertxThreads (may cause NullPointerException otherwise) We are intentionally avoiding
+   * vertx.getOrCreateContext() to ensure better coding practices
+   */
+  public static <T> void setInstanceInContext(String key, T object) {
+    Vertx.currentContext().put(CONTEXT_INSTANCE_PREFIX + CLASS_PREFIX + key, object);
+  }
+
+  public static <T> T getInstanceFromContext(String key) {
+    return Vertx.currentContext().get(CONTEXT_INSTANCE_PREFIX + CLASS_PREFIX + key);
+  }
+
+  record ThreadSafe<T>(@Getter T object) implements Shareable {}
+}

--- a/src/main/java/com/dreamsportslabs/guardian/verticle/MainVerticle.java
+++ b/src/main/java/com/dreamsportslabs/guardian/verticle/MainVerticle.java
@@ -1,0 +1,121 @@
+package com.dreamsportslabs.guardian.verticle;
+
+import static com.dreamsportslabs.guardian.constant.Constants.HTTP_CONNECT_TIMEOUT;
+import static com.dreamsportslabs.guardian.constant.Constants.HTTP_READ_TIMEOUT;
+import static com.dreamsportslabs.guardian.constant.Constants.HTTP_WRITE_TIMEOUT;
+import static com.dreamsportslabs.guardian.constant.Constants.PORT;
+import static com.dreamsportslabs.guardian.constant.Constants.REDIS_HOST;
+import static com.dreamsportslabs.guardian.constant.Constants.REDIS_PORT;
+import static com.dreamsportslabs.guardian.constant.Constants.REDIS_TYPE;
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_CONFIG_REFRESH_INTERVAL;
+
+import com.dreamsportslabs.guardian.cache.TenantCache;
+import com.dreamsportslabs.guardian.client.MysqlClient;
+import com.dreamsportslabs.guardian.client.impl.MysqlClientImpl;
+import com.dreamsportslabs.guardian.registry.Registry;
+import com.dreamsportslabs.guardian.utils.ConfigUtil;
+import com.dreamsportslabs.guardian.utils.SharedDataUtils;
+import io.reactivex.rxjava3.core.Completable;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.impl.cpu.CpuCoreSensor;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.redis.client.RedisClientType;
+import io.vertx.redis.client.RedisOptions;
+import io.vertx.rxjava3.core.AbstractVerticle;
+import io.vertx.rxjava3.ext.web.client.WebClient;
+import io.vertx.rxjava3.redis.client.Redis;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MainVerticle extends AbstractVerticle {
+  private Redis redisClient;
+  private WebClient webClient;
+  private MysqlClient mysqlClient;
+  private JsonObject config;
+
+  @Override
+  public Completable rxStart() {
+    SharedDataUtils.put(vertx.getDelegate(), new Registry());
+    return ConfigUtil.getConfigRetriever(vertx)
+        .rxGetConfig()
+        .map(
+            config -> {
+              this.config = config;
+              return config;
+            })
+        .flatMapCompletable(this::initializeClients)
+        .doOnComplete(
+            () ->
+                SharedDataUtils.put(
+                    vertx.getDelegate(),
+                    TenantCache.getInstance(
+                        Integer.parseInt(config.getString(TENANT_CONFIG_REFRESH_INTERVAL)))))
+        .andThen(
+            vertx.rxDeployVerticle(
+                () ->
+                    new RestVerticle(
+                        new HttpServerOptions().setPort(Integer.parseInt(config.getString(PORT)))),
+                new DeploymentOptions().setInstances(getNumOfCores())))
+        .ignoreElement();
+  }
+
+  private Integer getNumOfCores() {
+    return CpuCoreSensor.availableProcessors();
+  }
+
+  @Override
+  public Completable rxStop() {
+    this.redisClient.close();
+    this.webClient.close();
+
+    return this.mysqlClient.rxClose();
+  }
+
+  private Completable initializeClients(JsonObject config) {
+    return initializeMysqlClient(config)
+        .andThen(initializeRedisClient(config))
+        .andThen(initializeWebClient(config));
+  }
+
+  private Completable initializeMysqlClient(JsonObject config) {
+    this.mysqlClient = new MysqlClientImpl(this.vertx, config);
+
+    SharedDataUtils.put(vertx.getDelegate(), this.mysqlClient);
+
+    return mysqlClient.rxConnect();
+  }
+
+  private Completable initializeRedisClient(JsonObject config) {
+    RedisOptions redisOptions =
+        new RedisOptions()
+            .setConnectionString(
+                "redis://"
+                    + config.getString(REDIS_HOST)
+                    + ":"
+                    + config.getString(REDIS_PORT)
+                    + "/")
+            .setType(RedisClientType.valueOf(config.getString(REDIS_TYPE)));
+    this.redisClient = Redis.createClient(vertx, redisOptions);
+
+    SharedDataUtils.put(vertx.getDelegate(), this.redisClient);
+
+    return redisClient.rxConnect().ignoreElement();
+  }
+
+  private Completable initializeWebClient(JsonObject config) {
+    WebClientOptions options =
+        new WebClientOptions()
+            .setConnectTimeout(Integer.parseInt(config.getString(HTTP_CONNECT_TIMEOUT)))
+            .setIdleTimeoutUnit(TimeUnit.MILLISECONDS)
+            .setReadIdleTimeout(Integer.parseInt(config.getString(HTTP_READ_TIMEOUT)))
+            .setWriteIdleTimeout(Integer.parseInt(config.getString(HTTP_WRITE_TIMEOUT)));
+    this.webClient = WebClient.create(vertx, options);
+
+    SharedDataUtils.put(vertx.getDelegate(), this.webClient);
+
+    return Completable.complete();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/verticle/RestVerticle.java
+++ b/src/main/java/com/dreamsportslabs/guardian/verticle/RestVerticle.java
@@ -1,0 +1,33 @@
+package com.dreamsportslabs.guardian.verticle;
+
+import com.dream11.rest.AbstractRestVerticle;
+import com.dream11.rest.ClassInjector;
+import com.dream11.rest.provider.JsonProvider;
+import com.dream11.rest.provider.impl.JacksonProvider;
+import com.dreamsportslabs.guardian.injection.GuiceInjector;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.jackson.DatabindCodec;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RestVerticle extends AbstractRestVerticle {
+  private static final String PACKAGE_NAME = "com.dreamsportslabs.guardian";
+
+  public RestVerticle(HttpServerOptions options) {
+    super(PACKAGE_NAME, options);
+  }
+
+  @Override
+  protected ClassInjector getInjector() {
+    return GuiceInjector.getGuiceInjector();
+  }
+
+  protected JsonProvider getJsonProvider() {
+    return new JacksonProvider(
+        DatabindCodec.mapper()
+            .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false));
+  }
+}


### PR DESCRIPTION
## **User description**
@coderabbitai ignore


___

## **CodeAnt-AI Description**
- Adds the main application launcher (`Main.java`) integrating Vert.x and Guice for dependency injection and shared data management.
- Introduces core constants, enums, and data classes for channels, flows, response types, contacts, and templates.
- Implements DAOs for code and refresh token management, including SQL queries for configuration and token operations.
- Adds a request filter (`ConfigFilter`) to ensure tenant configuration is loaded and validated for each request.
- Provides a singleton Guice injector and a main Guice module for dependency bindings.
- Implements a registry system for tenant-specific object management and initialization.
- Adds the `AuthorizationService` for handling token/code generation, exchange, refresh, and logout logic.
- Integrates Facebook and Google identity providers for OAuth-based user identity retrieval.
- Supplies utilities for configuration loading, JSON/database conversion, shared data management, validation, and Vert.x instance management.
- Implements the main Vert.x verticle for application startup, client initialization, and REST API deployment.

This PR establishes the foundational backend architecture for a multi-tenant authentication/authorization service. It sets up dependency injection, configuration management, service registries, core utilities, and the main application flow, enabling scalable and maintainable development of authentication features.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>25 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Main.java</strong><dd><code>Add main application launcher with Vert.x and Guice integration</code></dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/Main.java
<li>Introduces the main entry point for the application, extending Vert.x <br>Launcher.<br> <li> Configures Vert.x options such as event loop pool size and worker pool <br>size.<br> <li> Initializes Guice dependency injection and shared data utilities.<br> <li> Sets deployment options for verticles.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-902dc791559970126601e12f92c2552ea36a3118a9832bb6aacdd41effac0e8f">+46/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Channel.java</strong><dd><code>Add Channel enum for communication channel types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/constant/Channel.java
<li>Defines a <code>Channel</code> enum for communication channels (EMAIL, SMS) with <br>string values.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-deae37eb9c5ea9b8e49f2797b4a7a8fb93a1c349a9a190f0fd8efb0380d9fe5f">+15/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Constants.java</strong><dd><code>Add application-wide constants for configuration and keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/constant/Constants.java
<li>Adds a comprehensive constants class for configuration keys, JWT <br>claims, cache keys, and other static values.<br> <li> Includes lists for response types and prohibited forwarding headers.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-d9cc7569deff04f8891fd6b347d9374232bc90571431e0ff0f4df40133254d94">+81/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Contact.java</strong><dd><code>Add Contact class with validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/constant/Contact.java
<li>Introduces a <code>Contact</code> class with channel, identifier, and template <br>fields.<br> <li> Provides a validation method for contact data.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-4b4a5461f5a728421c08dfec7ab16455923d1faeb86c6267eff8375f20dbcc32">+22/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Flow.java</strong><dd><code>Add Flow enum for authentication flow types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/constant/Flow.java
<li>Defines a <code>Flow</code> enum for authentication flows (SIGNINUP, SIGNIN, <br>SIGNUP).<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-273511739dad8d57240584b05b7ef7cedcfca9f7fc2dc1edfd566cdd5887c49c">+16/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ResponseType.java</strong><dd><code>Add ResponseType enum for supported response types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/constant/ResponseType.java
- Adds a `ResponseType` enum for response types (CODE, TOKEN).



</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-ec33dc137348c742fe2f652868e312d6768a1a7610a897028370f016304ec135">+15/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Template.java</strong><dd><code>Add Template class for message templates with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/constant/Template.java
<li>Introduces a <code>Template</code> class with name and parameter map.<br> <li> Includes validation for template name.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-54907c7a44dc8e061d2c73e92e47d96011fe456f132256e10fb86a047eb6ad01">+21/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>CodeDao.java</strong><dd><code>Add CodeDao for code management in Redis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dao/CodeDao.java
<li>Implements a DAO for code storage and retrieval using Redis.<br> <li> Provides methods to save, get, and delete codes.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-10c239ac91271318d3976fcdbf98fa6b8fc943c3d28defa6b170f8b9ff24131a">+51/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ConfigQuery.java</strong><dd><code>Add SQL queries for configuration data retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dao/query/ConfigQuery.java
<li>Adds SQL query strings for various configuration tables (SMS, email, <br>user, token, OTP, etc.).<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-45cc063714c1e27786b9a56d446524b43a3a5589811a1641be8a6a366482109c">+91/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RefreshTokenSql.java</strong><dd><code>Add SQL queries for refresh token management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/dao/query/RefreshTokenSql.java
<li>Provides SQL statements for refresh token operations (save, validate, <br>invalidate, retrieve).<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-6b996811e92f39ab6bc513e92dddf45aaac2a75a84722b1480d777538f5a87cc">+18/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ConfigFilter.java</strong><dd><code>Add ConfigFilter for tenant configuration validation in requests</code></dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/filter/ConfigFilter.java
<li>Implements a JAX-RS request filter for tenant configuration validation <br>and loading.<br> <li> Suspends and resumes requests based on tenant config availability.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-0f75fa9ed2cebfd401625e16afbe9df7d8af4541e44393b87e69a8adeab7b481">+58/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>GuiceInjector.java</strong><dd><code>Add GuiceInjector singleton for dependency injection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/injection/GuiceInjector.java
<li>Implements a singleton Guice injector for dependency management.<br> <li> Provides methods to initialize and retrieve the injector.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-aeaa492f9b1f9117efe1ee404c91af09fd610aa3ad59059b33c31482dd91c51b">+38/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>MainModule.java</strong><dd><code>Add MainModule Guice module for service bindings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/injection/MainModule.java
<li>Defines a Guice module binding core services and clients to their <br>implementations.<br> <li> Integrates Vert.x, Redis, WebClient, Registry, and TenantCache.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-3afb2539ad62675042b8853a864379de1c0fc80db269e26166591ce621557a83">+31/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Registry.java</strong><dd><code>Add Registry for tenant-specific object management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/registry/Registry.java
<li>Implements a registry for storing and retrieving tenant-specific <br>objects.<br> <li> Supports named and default object storage.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-a748e2bdc9410534cf0cf7110bfeb6eabf50db23a6cde72dd32b93c7d2e8e203">+39/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RegistryInit.java</strong><dd><code>Add RegistryInit for tenant registry initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/registry/RegistryInit.java
<li>Provides logic to initialize the Registry with tenant configuration <br>and related providers.<br> <li> Supports RSA signer initialization based on token config.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-1bcd4cf6eac95fba786aa2f95ec8ef1e6ba06d7f0cbac0a66eeb24e457928a9b">+33/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>AuthorizationService.java</strong><dd><code>Add AuthorizationService for token and code management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/service/AuthorizationService.java
<li>Implements core authorization logic: token generation, code <br>generation, token exchange, refresh, and logout.<br> <li> Integrates with DAOs and registry for multi-tenant support.<br> <li> Handles refresh token revocation and access token issuance.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-d06af1d53743f039584e0db94e1ae5b804b6aeb787a96d8ffc4254ebc61afaeb">+192/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>FacebookIdProvider.java</strong><dd><code>Add FacebookIdProvider for Facebook OAuth integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/service/impl/idproviders/FacebookIdProvider.java
<li>Implements Facebook identity provider integration for user identity <br>retrieval.<br> <li> Handles access token validation and error scenarios.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-af0dba3982291e3eea1170d3455339ef4b8aa8a5b27cb7d7792bdcf336e1a155">+57/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>GoogleIdProvider.java</strong><dd><code>Add GoogleIdProvider for Google OAuth integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/service/impl/idproviders/GoogleIdProvider.java
<li>Implements Google identity provider integration for user identity <br>retrieval.<br> <li> Verifies Google ID tokens and extracts user information.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-679ea50ae790d4554ee023ea892edad44b22fc98e354ad3eec738e2a5e113ce5">+50/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ConfigUtil.java</strong><dd><code>Add ConfigUtil for application configuration loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/utils/ConfigUtil.java
<li>Adds utility for loading application configuration from HOCON files <br>using Vert.x ConfigRetriever.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-5f4c459978754da26d9964a1f20756d6895cb48cd4a61ce738573f2bcb5af907">+29/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>JsonUtils.java</strong><dd><code>Add JsonUtils for JSON and database row conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/utils/JsonUtils.java
<li>Provides utilities for JSON manipulation and conversion between <br>RowSets and POJOs.<br> <li> Supports snake_case mapping and nested JSON extraction.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-99766f9bee30847096596e5b686c8ea69145f7033f27391d7ba68a6a25213adf">+61/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>SharedDataUtils.java</strong><dd><code>Add SharedDataUtils for Vert.x shared singleton management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/utils/SharedDataUtils.java
<li>Implements shared data utilities for storing and retrieving singleton <br>instances in Vert.x.<br> <li> Supports thread-safe instance management.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-12bdfbefae2c7d1afdd7d045c805cb12a1a22ad24ea3c09ee9044f5a88775d22">+66/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Utils.java</strong><dd><code>Add Utils for validation and header utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/utils/Utils.java
<li>Adds utility methods for email/mobile validation, header filtering, <br>and MD5 hashing.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-ad610ca6cdbe1929e240b9c0c5a70ee6413186fad29a1b5ad5922ca66bc12f88">+40/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>VertxUtil.java</strong><dd><code>Add VertxUtil for advanced Vert.x instance management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/utils/VertxUtil.java
<li>Provides advanced utilities for managing shared and context-specific <br>instances in Vert.x.<br> <li> Supports thread-safe singleton and context storage.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-a4f6edc1b2144356f7b9b1f495d31c3fedd9f32a8a6edc861a0665bc3570fbdc">+92/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>MainVerticle.java</strong><dd><code>Add MainVerticle for application startup and service initialization</code></dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/verticle/MainVerticle.java
<li>Implements the main Vert.x verticle for application startup.<br> <li> Initializes configuration, clients (MySQL, Redis, WebClient), and <br>deploys the REST verticle.<br> <li> Manages shared data for core services.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-1e41bcc24970bdf36324eea39e7fbc6f627c395c41a2e4c1c2e9debb9d70cebe">+121/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RestVerticle.java</strong><dd><code>Add RestVerticle for REST API server setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/verticle/RestVerticle.java
<li>Implements the REST verticle for HTTP server setup.<br> <li> Integrates Guice injector and Jackson JSON provider.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/9/files#diff-3f44a6a295e7bbfdfbeaeae3813bebe3256b04a5a0686da8832c6b7959bda073">+33/-0</a>&nbsp; &nbsp; </td>
</tr>
</table></details></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
