### PR TITLE
chore: add code 4

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/client/MysqlClient.java
+++ b/src/main/java/com/dreamsportslabs/guardian/client/MysqlClient.java
@@ -1,0 +1,15 @@
+package com.dreamsportslabs.guardian.client;
+
+import io.reactivex.rxjava3.core.Completable;
+import io.vertx.rxjava3.mysqlclient.MySQLPool;
+
+public interface MysqlClient {
+
+  MySQLPool getWriterPool();
+
+  MySQLPool getReaderPool();
+
+  Completable rxConnect();
+
+  Completable rxClose();
+}

--- a/src/main/java/com/dreamsportslabs/guardian/client/impl/MysqlClientImpl.java
+++ b/src/main/java/com/dreamsportslabs/guardian/client/impl/MysqlClientImpl.java
@@ -1,0 +1,75 @@
+package com.dreamsportslabs.guardian.client.impl;
+
+import static com.dreamsportslabs.guardian.constant.Constants.MYSQL_DATABASE;
+import static com.dreamsportslabs.guardian.constant.Constants.MYSQL_PASSWORD;
+import static com.dreamsportslabs.guardian.constant.Constants.MYSQL_READER_HOST;
+import static com.dreamsportslabs.guardian.constant.Constants.MYSQL_READER_MAX_POOL_SIZE;
+import static com.dreamsportslabs.guardian.constant.Constants.MYSQL_USER;
+import static com.dreamsportslabs.guardian.constant.Constants.MYSQL_WRITER_HOST;
+import static com.dreamsportslabs.guardian.constant.Constants.MYSQL_WRITER_MAX_POOL_SIZE;
+
+import com.dreamsportslabs.guardian.client.MysqlClient;
+import io.reactivex.rxjava3.core.Completable;
+import io.vertx.core.json.JsonObject;
+import io.vertx.mysqlclient.MySQLConnectOptions;
+import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.mysqlclient.MySQLPool;
+import io.vertx.sqlclient.PoolOptions;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MysqlClientImpl implements MysqlClient {
+  private final Vertx vertx;
+  private final JsonObject config;
+  private MySQLPool writerPool;
+  private MySQLPool readerPool;
+
+  public MysqlClientImpl(Vertx vertx, JsonObject config) {
+    this.vertx = vertx;
+    this.config = config;
+    createConnectionPool();
+  }
+
+  public Completable rxConnect() {
+    return Completable.complete();
+  }
+
+  @Override
+  public Completable rxClose() {
+    return this.writerPool.rxClose().andThen(this.readerPool.rxClose());
+  }
+
+  private void createConnectionPool() {
+    log.info(config.toString());
+    MySQLConnectOptions writerConnectOptions =
+        new MySQLConnectOptions()
+            .setHost(this.config.getString(MYSQL_WRITER_HOST))
+            .setUser(this.config.getString(MYSQL_USER))
+            .setPassword(this.config.getString(MYSQL_PASSWORD))
+            .setDatabase(this.config.getString(MYSQL_DATABASE));
+    PoolOptions writerPoolOptions =
+        new PoolOptions()
+            .setMaxSize(Integer.parseInt(this.config.getString(MYSQL_WRITER_MAX_POOL_SIZE)));
+
+    MySQLConnectOptions readerConnectOptions =
+        new MySQLConnectOptions()
+            .setHost(this.config.getString(MYSQL_READER_HOST))
+            .setUser(this.config.getString(MYSQL_USER))
+            .setPassword(this.config.getString(MYSQL_PASSWORD))
+            .setDatabase(this.config.getString(MYSQL_DATABASE));
+    PoolOptions readerPoolOptions =
+        new PoolOptions()
+            .setMaxSize(Integer.parseInt(this.config.getString(MYSQL_READER_MAX_POOL_SIZE)));
+
+    this.writerPool = MySQLPool.pool(this.vertx, writerConnectOptions, writerPoolOptions);
+    this.readerPool = MySQLPool.pool(this.vertx, readerConnectOptions, readerPoolOptions);
+  }
+
+  public MySQLPool getWriterPool() {
+    return this.writerPool;
+  }
+
+  public MySQLPool getReaderPool() {
+    return this.readerPool;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/exception/ErrorEnum.java
+++ b/src/main/java/com/dreamsportslabs/guardian/exception/ErrorEnum.java
@@ -1,0 +1,111 @@
+package com.dreamsportslabs.guardian.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import lombok.Getter;
+
+public enum ErrorEnum {
+  INVALID_REQUEST("invalid_request", "Invalid request params", 400),
+  UNAUTHORIZED("unauthorized", "Unauthorized", 401),
+  INTERNAL_SERVER_ERROR("internal_server_error", "Something went wrong", 500),
+  USER_SERVICE_ERROR("user_service_error", "User service error", 500),
+  SMS_SERVICE_ERROR("sms_service_error", "SMS service error", 500),
+  EMAIL_SERVICE_ERROR("email_service_error", "Email service error", 500),
+
+  INVALID_CODE("invalid_code", "Invalid code", 400),
+
+  INVALID_STATE("invalid_state", "Invalid state", 400),
+  RESENDS_EXHAUSTED("resends_exhausted", "Resends exhausted", 400),
+  RESEND_NOT_ALLOWED("resends_not_allowed", "Resend triggered too quick, Try again later", 400),
+  INCORRECT_OTP("incorrect_otp", "Incorrect otp", 400),
+  RETRIES_EXHAUSTED("retries_exhausted", "Retries exhausted", 400),
+
+  USER_EXISTS("user_exists", "User already exists", 400),
+  USER_NOT_EXISTS("user_not_exists", "User does not exist", 400);
+
+  private final String code;
+  private final String message;
+  private final int httpStatusCode;
+
+  @Getter private final WebApplicationException exception;
+
+  ErrorEnum(String code, String message, int httpStatusCode) {
+    this.code = code;
+    this.message = message;
+    this.httpStatusCode = httpStatusCode;
+    Response response =
+        Response.status(httpStatusCode)
+            .header("Content-Type", "application/json")
+            .entity(new ErrorEntity(code, message))
+            .build();
+    this.exception = new WebApplicationException(response);
+  }
+
+  public WebApplicationException getException(Throwable t) {
+    return new WebApplicationException(t, this.exception.getResponse());
+  }
+
+  public WebApplicationException getCustomException(String message) {
+    message = message == null ? this.message : message;
+
+    Response response =
+        Response.status(this.httpStatusCode)
+            .header("Content-Type", "application/json")
+            .entity(new ErrorEntity(this.code, message))
+            .build();
+    return new WebApplicationException(response);
+  }
+
+  public WebApplicationException getCustomException(Map<String, Object> data) {
+    Response response =
+        Response.status(this.httpStatusCode)
+            .header("Content-Type", "application/json")
+            .entity(new ErrorEntity(this.code, this.message, data))
+            .build();
+    return new WebApplicationException(response);
+  }
+
+  public WebApplicationException getCustomException(String message, Map<String, Object> data) {
+    message = message == null ? this.message : message;
+
+    Response response =
+        Response.status(this.httpStatusCode)
+            .header("Content-Type", "application/json")
+            .entity(new ErrorEntity(this.code, message, data))
+            .build();
+    return new WebApplicationException(response);
+  }
+
+  @Getter
+  static class ErrorEntity {
+    final Error error;
+
+    ErrorEntity(String code, String message) {
+      this.error = new Error(code, message);
+    }
+
+    ErrorEntity(String code, String message, Map<String, Object> data) {
+      this.error = new Error(code, message, data);
+    }
+
+    @Getter
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    static class Error {
+      final String code;
+      final String message;
+      final Map<String, Object> metadata;
+
+      Error(String code, String message) {
+        this(code, message, null);
+      }
+
+      Error(String code, String message, Map<String, Object> metadata) {
+        this.code = code;
+        this.message = message;
+        this.metadata = metadata;
+      }
+    }
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/exception/GenericExceptionMapper.java
+++ b/src/main/java/com/dreamsportslabs/guardian/exception/GenericExceptionMapper.java
@@ -1,0 +1,18 @@
+package com.dreamsportslabs.guardian.exception;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import lombok.extern.slf4j.Slf4j;
+
+@Provider
+@Slf4j
+public class GenericExceptionMapper implements ExceptionMapper<Throwable> {
+  @Override
+  public Response toResponse(Throwable exception) {
+    log.error("GenericException", exception);
+    WebApplicationException e = ErrorEnum.INTERNAL_SERVER_ERROR.getException();
+    return e.getResponse();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/exception/WebApplicationExceptionMapper.java
+++ b/src/main/java/com/dreamsportslabs/guardian/exception/WebApplicationExceptionMapper.java
@@ -1,0 +1,18 @@
+package com.dreamsportslabs.guardian.exception;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import lombok.extern.slf4j.Slf4j;
+
+@Provider
+@Slf4j
+public class WebApplicationExceptionMapper implements ExceptionMapper<WebApplicationException> {
+
+  @Override
+  public Response toResponse(WebApplicationException e) {
+    log.error("WebApplicationException", e);
+    return e.getResponse();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/package-info.java
+++ b/src/main/java/com/dreamsportslabs/guardian/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(groupPackage = "com.dreamsportslabs.guardian", name = "Guardian")
+package com.dreamsportslabs.guardian;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/src/main/java/com/dreamsportslabs/guardian/rest/AuthFb.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/AuthFb.java
@@ -1,0 +1,37 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.V1AuthFbRequestDto;
+import com.dreamsportslabs.guardian.service.SocialAuthService;
+import com.google.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Path("/v1/auth/fb")
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class AuthFb {
+  private final SocialAuthService socialAuthService;
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> authFb(@Context HttpHeaders headers, V1AuthFbRequestDto dto) {
+    dto.validate();
+    String tenantId = headers.getHeaderString(TENANT_ID);
+    return socialAuthService
+        .authFb(dto, headers.getRequestHeaders(), tenantId)
+        .map(res -> Response.ok(res).build())
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/rest/AuthGoogle.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/AuthGoogle.java
@@ -1,0 +1,39 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.V1AuthGoogleRequestDto;
+import com.dreamsportslabs.guardian.service.SocialAuthService;
+import com.google.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Path("/v1/auth/google")
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class AuthGoogle {
+  private final SocialAuthService socialAuthService;
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> authIdp(
+      @Context HttpHeaders headers, V1AuthGoogleRequestDto dto) {
+    dto.validate();
+
+    String tenantId = headers.getHeaderString(TENANT_ID);
+    return socialAuthService
+        .authGoogle(dto, headers.getRequestHeaders(), tenantId)
+        .map(res -> Response.ok(res).build())
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/rest/CodeTokenExchange.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/CodeTokenExchange.java
@@ -1,0 +1,37 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.V1CodeTokenExchangeRequestDto;
+import com.dreamsportslabs.guardian.service.AuthorizationService;
+import com.google.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Path("/v1/code-token-exchange")
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class CodeTokenExchange {
+  private final AuthorizationService authorizationService;
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> codeTokenExchange(
+      @HeaderParam(TENANT_ID) String tenantId, V1CodeTokenExchangeRequestDto dto) {
+    dto.validate();
+
+    return authorizationService
+        .codeTokenExchange(dto, tenantId)
+        .map(res -> Response.ok(res).build())
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/rest/HealthCheck.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/HealthCheck.java
@@ -1,0 +1,27 @@
+package com.dreamsportslabs.guardian.rest;
+
+import com.google.inject.Inject;
+import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+@Path("/healthcheck")
+public class HealthCheck {
+  @GET
+  @Consumes(MediaType.WILDCARD)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Hidden
+  public CompletionStage<Response> healthcheck() {
+    return CompletableFuture.supplyAsync(() -> Response.ok().build());
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/rest/Login.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/Login.java
@@ -1,0 +1,39 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.V1LoginRequestDto;
+import com.dreamsportslabs.guardian.service.PasswordAuth;
+import com.google.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Path("/v1/signin")
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class Login {
+  private final PasswordAuth passwordAuth;
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> login(
+      @Context HttpHeaders headers, V1LoginRequestDto requestDto) {
+    requestDto.validate();
+    String tenantId = headers.getHeaderString(TENANT_ID);
+
+    return passwordAuth
+        .login(requestDto, headers.getRequestHeaders(), tenantId)
+        .map(dto -> Response.ok(dto).build())
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/rest/Logout.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/Logout.java
@@ -1,0 +1,43 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.V1LogoutRequestDto;
+import com.dreamsportslabs.guardian.service.AuthorizationService;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Path("/v1/logout")
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class Logout {
+  private final AuthorizationService authorizationService;
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> logout(
+      @Context HttpHeaders headers, V1LogoutRequestDto requestDto) {
+    if (requestDto == null) {
+      requestDto = new V1LogoutRequestDto();
+    }
+    String tenantId = headers.getHeaderString(TENANT_ID);
+
+    requestDto.validate();
+    return authorizationService
+        .logout(requestDto, tenantId)
+        .andThen(Single.just(Response.noContent().build()))
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/rest/PasswordlessComplete.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/PasswordlessComplete.java
@@ -1,0 +1,36 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.V1PasswordlessCompleteRequestDto;
+import com.dreamsportslabs.guardian.service.Passwordless;
+import com.google.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Path("/v1/passwordless/complete")
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class PasswordlessComplete {
+  private final Passwordless passwordless;
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> complete(
+      @HeaderParam(TENANT_ID) String tenantId, V1PasswordlessCompleteRequestDto dto) {
+    dto.validate();
+    return passwordless
+        .complete(dto, tenantId)
+        .map(res -> Response.ok(res).build())
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/rest/PasswordlessInit.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/PasswordlessInit.java
@@ -1,0 +1,50 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.V1PasswordlessInitRequestDto;
+import com.dreamsportslabs.guardian.dto.response.V1PasswordlessInitResponseDto;
+import com.dreamsportslabs.guardian.service.Passwordless;
+import com.google.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+@Path("/v1/passwordless/init")
+public class PasswordlessInit {
+  private final Passwordless passwordless;
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> init(
+      @Context HttpHeaders headers, V1PasswordlessInitRequestDto requestDto) {
+    requestDto.validate();
+    return passwordless
+        .init(requestDto, headers.getRequestHeaders(), headers.getHeaderString(TENANT_ID))
+        .map(
+            model ->
+                Response.ok(
+                        V1PasswordlessInitResponseDto.builder()
+                            .tries(model.getTries())
+                            .retriesLeft(model.getMaxTries() - model.getTries())
+                            .resends(model.getResends())
+                            .resendsLeft(model.getMaxResends() - model.getResends())
+                            .resendAfter(model.getResendAfter())
+                            .isNewUser(model.getUser().get("isNewUser") != null)
+                            .state(model.getState())
+                            .build())
+                    .build())
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/rest/RefreshToken.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/RefreshToken.java
@@ -1,0 +1,36 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.V1RefreshTokenRequestDto;
+import com.dreamsportslabs.guardian.service.AuthorizationService;
+import com.google.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+@Path("/v1/refreshToken")
+public class RefreshToken {
+  private final AuthorizationService authorizationService;
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> refreshTokens(
+      @Context HttpHeaders headers, V1RefreshTokenRequestDto requestDto) {
+    String tenantId = headers.getHeaderString(TENANT_ID);
+    requestDto.validate();
+    return authorizationService
+        .refreshTokens(requestDto, tenantId)
+        .map(dto -> Response.ok(dto).build())
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/rest/Register.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/Register.java
@@ -1,0 +1,39 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.V1RegisterRequestDto;
+import com.dreamsportslabs.guardian.service.PasswordAuth;
+import com.google.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Path("/v1/signup")
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class Register {
+  private final PasswordAuth passwordAuth;
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> authenticate(
+      @Context HttpHeaders headers, V1RegisterRequestDto requestDto) {
+    requestDto.validate();
+
+    String tenantId = headers.getHeaderString(TENANT_ID);
+    return passwordAuth
+        .register(requestDto, headers.getRequestHeaders(), tenantId)
+        .map(dto -> Response.ok(dto).build())
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/rest/Revocations.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/Revocations.java
@@ -1,0 +1,37 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.RevocationRequestDto;
+import com.dreamsportslabs.guardian.service.RevocationService;
+import com.google.inject.Inject;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+@Path("/revocations")
+public class Revocations {
+  private final RevocationService revocationService;
+
+  @GET
+  @Consumes(MediaType.WILDCARD)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> getRevocations(
+      @Context HttpHeaders headers, @BeanParam RevocationRequestDto requestDto) {
+    String tenantId = headers.getHeaderString(TENANT_ID);
+
+    return revocationService
+        .getRevocations(requestDto, tenantId)
+        .map(dto -> Response.ok(dto).build())
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/IdProvider.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/IdProvider.java
@@ -1,0 +1,8 @@
+package com.dreamsportslabs.guardian.service;
+
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+
+public interface IdProvider {
+  Single<JsonObject> getUserIdentity(String authorizationToken);
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/OtpService.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/OtpService.java
@@ -1,0 +1,92 @@
+package com.dreamsportslabs.guardian.service;
+
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.EMAIL_SERVICE_ERROR;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INTERNAL_SERVER_ERROR;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.SMS_SERVICE_ERROR;
+
+import com.dreamsportslabs.guardian.config.tenant.EmailConfig;
+import com.dreamsportslabs.guardian.config.tenant.SmsConfig;
+import com.dreamsportslabs.guardian.config.tenant.TenantConfig;
+import com.dreamsportslabs.guardian.constant.Channel;
+import com.dreamsportslabs.guardian.constant.Contact;
+import com.dreamsportslabs.guardian.registry.Registry;
+import com.dreamsportslabs.guardian.utils.Utils;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.ext.web.client.WebClient;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class OtpService {
+  private final WebClient webClient;
+  private final Registry registry;
+
+  public Completable sendOtp(
+      List<Contact> contacts, String otp, MultivaluedMap<String, String> headers, String tenantId) {
+    List<Completable> completables = new ArrayList<>();
+    for (Contact contact : contacts) {
+      contact.getTemplate().getParams().put("otp", otp);
+      if (contact.getChannel().equals(Channel.EMAIL)) {
+        completables.add(sendOtpViaEmail(contact, headers, tenantId));
+      } else {
+        completables.add(sendOtpViaSms(contact, headers, tenantId));
+      }
+    }
+    return Completable.merge(completables);
+  }
+
+  public Completable sendOtpViaSms(
+      Contact contact, MultivaluedMap<String, String> headers, String tenantId) {
+    SmsConfig config = registry.get(tenantId, TenantConfig.class).getSmsConfig();
+    return webClient
+        .post(config.getPort(), config.getHost(), config.getSendSmsPath())
+        .ssl(config.isSslEnabled())
+        .putHeaders(Utils.getForwardingHeaders(headers))
+        .rxSendJson(
+            new JsonObject()
+                .put("channel", contact.getChannel().getName())
+                .put("to", contact.getIdentifier())
+                .put("templateName", contact.getTemplate().getName())
+                .put("templateParams", contact.getTemplate().getParams()))
+        .onErrorResumeNext(err -> Single.error(INTERNAL_SERVER_ERROR.getException(err)))
+        .map(
+            res -> {
+              if (res.statusCode() / 100 != 2) {
+                throw SMS_SERVICE_ERROR.getCustomException(res.bodyAsJsonObject().getMap());
+              }
+              return res;
+            })
+        .ignoreElement();
+  }
+
+  public Completable sendOtpViaEmail(
+      Contact contact, MultivaluedMap<String, String> headers, String tenantId) {
+    EmailConfig config = registry.get(tenantId, TenantConfig.class).getEmailConfig();
+    return webClient
+        .post(config.getPort(), config.getHost(), config.getSendEmailPath())
+        .ssl(config.isSslEnabled())
+        .putHeaders(Utils.getForwardingHeaders(headers))
+        .rxSendJson(
+            new JsonObject()
+                .put("channel", contact.getChannel().getName())
+                .put("to", contact.getIdentifier())
+                .put("templateName", contact.getTemplate().getName())
+                .put("templateParams", contact.getTemplate().getParams()))
+        .onErrorResumeNext(err -> Single.error(INTERNAL_SERVER_ERROR.getException(err)))
+        .map(
+            res -> {
+              if (res.statusCode() / 100 != 2) {
+                throw EMAIL_SERVICE_ERROR.getCustomException(res.bodyAsJsonObject().getMap());
+              }
+              return res;
+            })
+        .ignoreElement();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/PasswordAuth.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/PasswordAuth.java
@@ -1,0 +1,51 @@
+package com.dreamsportslabs.guardian.service;
+
+import com.dreamsportslabs.guardian.dto.UserDto;
+import com.dreamsportslabs.guardian.dto.request.V1LoginRequestDto;
+import com.dreamsportslabs.guardian.dto.request.V1RegisterRequestDto;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.core.MultivaluedMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class PasswordAuth {
+  private final UserService userService;
+  private final AuthorizationService authorizationService;
+
+  public Single<Object> login(
+      V1LoginRequestDto dto, MultivaluedMap<String, String> headers, String tenantId) {
+    return userService
+        .authenticate(
+            UserDto.builder()
+                .username(dto.getUsername())
+                .password(dto.getPassword())
+                .additionalInfo(dto.getAdditionalInfo())
+                .build(),
+            headers,
+            tenantId)
+        .flatMap(
+            user ->
+                authorizationService.generate(
+                    user, dto.getResponseType(), dto.getMetaInfo(), tenantId));
+  }
+
+  public Single<Object> register(
+      V1RegisterRequestDto dto, MultivaluedMap<String, String> headers, String tenantId) {
+    return userService
+        .createUser(
+            UserDto.builder()
+                .username(dto.getUsername())
+                .password(dto.getPassword())
+                .additionalInfo(dto.getAdditionalInfo())
+                .build(),
+            headers,
+            tenantId)
+        .flatMap(
+            user ->
+                authorizationService.generate(
+                    user, dto.getResponseType(), dto.getMetaInfo(), tenantId));
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/Passwordless.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/Passwordless.java
@@ -1,0 +1,236 @@
+package com.dreamsportslabs.guardian.service;
+
+import static com.dreamsportslabs.guardian.constant.Constants.EMAIL;
+import static com.dreamsportslabs.guardian.constant.Constants.PHONE;
+import static com.dreamsportslabs.guardian.constant.Constants.STATIC_OTP_NUMBER;
+import static com.dreamsportslabs.guardian.constant.Constants.USERID;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INCORRECT_OTP;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_STATE;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.RESENDS_EXHAUSTED;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.RESEND_NOT_ALLOWED;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.RETRIES_EXHAUSTED;
+
+import com.dreamsportslabs.guardian.config.tenant.OtpConfig;
+import com.dreamsportslabs.guardian.config.tenant.TenantConfig;
+import com.dreamsportslabs.guardian.constant.Channel;
+import com.dreamsportslabs.guardian.constant.Contact;
+import com.dreamsportslabs.guardian.constant.Template;
+import com.dreamsportslabs.guardian.dao.PasswordlessDao;
+import com.dreamsportslabs.guardian.dao.model.PasswordlessModel;
+import com.dreamsportslabs.guardian.dto.UserDto;
+import com.dreamsportslabs.guardian.dto.request.V1PasswordlessCompleteRequestDto;
+import com.dreamsportslabs.guardian.dto.request.V1PasswordlessInitRequestDto;
+import com.dreamsportslabs.guardian.registry.Registry;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class Passwordless {
+  private final UserService userService;
+  private final OtpService otpService;
+  private final PasswordlessDao passwordlessDao;
+  private final AuthorizationService authorizationService;
+  private final Registry registry;
+
+  public Single<PasswordlessModel> init(
+      V1PasswordlessInitRequestDto requestDto,
+      MultivaluedMap<String, String> headers,
+      String tenantId) {
+    String state = requestDto.getState();
+    Single<PasswordlessModel> passwordlessModel;
+    if (state != null) {
+      passwordlessModel = this.getPasswordlessModel(state, tenantId);
+    } else {
+      updateDefaultTemplate(requestDto, tenantId);
+      passwordlessModel = this.createPasswordlessModel(requestDto, headers, tenantId);
+    }
+    return passwordlessModel
+        .map(
+            model -> {
+              if (model.getResends() >= model.getMaxResends()) {
+                passwordlessDao.deletePasswordlessModel(state, tenantId);
+                throw RESENDS_EXHAUSTED.getException();
+              }
+
+              if ((System.currentTimeMillis() / 1000) < model.getResendAfter()) {
+                throw RESEND_NOT_ALLOWED.getCustomException(
+                    Map.of("resendAfter", model.getResendAfter()));
+              }
+
+              return model;
+            })
+        .flatMap(
+            model -> {
+              if (Boolean.TRUE.equals(model.getIsOtpMocked())) {
+                return Single.just(model);
+              }
+              return otpService
+                  .sendOtp(model.getContacts(), model.getOtp(), headers, tenantId)
+                  .andThen(Single.just(model));
+            })
+        .map(PasswordlessModel::updateResend)
+        .flatMap(model -> passwordlessDao.setPasswordlessModel(model, tenantId));
+  }
+
+  private void updateDefaultTemplate(V1PasswordlessInitRequestDto requestDto, String tenantId) {
+    TenantConfig tenantConfig = registry.get(tenantId, TenantConfig.class);
+    for (Contact contact : requestDto.getContacts()) {
+      if (contact.getTemplate() == null) {
+        if (contact.getChannel() == Channel.EMAIL) {
+          contact.setTemplate(
+              new Template(
+                  tenantConfig.getEmailConfig().getTemplateName(),
+                  tenantConfig.getEmailConfig().getTemplateParams()));
+        }
+        if (contact.getChannel() == Channel.SMS) {
+          contact.setTemplate(
+              new Template(
+                  tenantConfig.getSmsConfig().getTemplateName(),
+                  tenantConfig.getSmsConfig().getTemplateParams()));
+        }
+      }
+    }
+  }
+
+  private Single<PasswordlessModel> getPasswordlessModel(String state, String tenantId) {
+    return passwordlessDao
+        .getPasswordlessModel(state, tenantId)
+        .switchIfEmpty(Single.error(INVALID_STATE.getException()))
+        .map(
+            model -> {
+              if (System.currentTimeMillis() / 1000 > model.getExpiry()) {
+                passwordlessDao.deletePasswordlessModel(state, tenantId);
+                throw INVALID_STATE.getException();
+              }
+              return model;
+            });
+  }
+
+  private Single<PasswordlessModel> createPasswordlessModel(
+      V1PasswordlessInitRequestDto dto, MultivaluedMap<String, String> headers, String tenantId) {
+    Map<String, String> userFilters = new HashMap<>();
+    for (Contact contact : dto.getContacts()) {
+      if (contact.getChannel() == Channel.EMAIL) {
+        userFilters.put(EMAIL, contact.getIdentifier());
+      }
+
+      if (contact.getChannel() == Channel.SMS) {
+        userFilters.put(PHONE, contact.getIdentifier());
+      }
+    }
+    return userService
+        .getUser(userFilters, headers, tenantId)
+        .map(
+            user -> {
+              OtpConfig config = registry.get(tenantId, TenantConfig.class).getOtpConfig();
+              Map<String, String> h = new HashMap<>();
+              headers.forEach((key, val) -> h.put(key, val.get(0)));
+              return PasswordlessModel.builder()
+                  .state(generateState())
+                  .otp(generateOtp(config, dto.getContacts()))
+                  .isOtpMocked(config.getIsOtpMocked())
+                  .resends(-1)
+                  .resendAfter(0L)
+                  .resendInterval(config.getOtpResendInterval())
+                  .maxTries(config.getTryLimit())
+                  .maxResends(config.getResendLimit())
+                  .user(user.getMap())
+                  .headers(h)
+                  .contacts(dto.getContacts())
+                  .flow(dto.getFlow())
+                  .responseType(dto.getResponseType())
+                  .metaInfo(dto.getMetaInfo())
+                  .additionalInfo(dto.getAdditionalInfo())
+                  .expiry(System.currentTimeMillis() / 1000 + config.getOtpValidity())
+                  .build();
+            });
+  }
+
+  private String generateState() {
+    return RandomStringUtils.randomAlphanumeric(10);
+  }
+
+  private String generateOtp(OtpConfig config, List<Contact> contacts) {
+    if (Boolean.TRUE.equals(config.getIsOtpMocked())) {
+      return StringUtils.repeat(STATIC_OTP_NUMBER, config.getOtpLength());
+    }
+
+    for (Contact contact : contacts) {
+      String whitelistedOtp = config.getWhitelistedInputs().get(contact.getIdentifier());
+      if (whitelistedOtp != null) {
+        return whitelistedOtp;
+      }
+    }
+    return RandomStringUtils.random(config.getOtpLength(), false, true);
+  }
+
+  public Single<Object> complete(V1PasswordlessCompleteRequestDto dto, String tenantId) {
+    return getPasswordlessModel(dto.getState(), tenantId)
+        .map(
+            model -> {
+              if (model.getTries() >= model.getMaxTries()) {
+                passwordlessDao.deletePasswordlessModel(model.getState(), tenantId);
+                throw RETRIES_EXHAUSTED.getException();
+              }
+              return model;
+            })
+        .flatMap(model -> validateOtp(model, dto.getOtp(), tenantId))
+        .flatMap(
+            model -> {
+              if (model.getUser().get(USERID) != null) {
+                return Single.just(model);
+              }
+              UserDto.UserDtoBuilder builder = UserDto.builder();
+              Contact contact = model.getContacts().get(0);
+              if (contact.getChannel() == Channel.EMAIL) {
+                builder.email(contact.getIdentifier());
+              } else {
+                builder.phoneNumber(contact.getIdentifier());
+              }
+              builder.additionalInfo(model.getAdditionalInfo());
+              MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+              model.getHeaders().forEach(headers::add);
+              return userService
+                  .createUser(builder.build(), headers, tenantId)
+                  .map(
+                      user -> {
+                        model.setUser(user.getMap());
+                        return model;
+                      });
+            })
+        .flatMap(
+            model ->
+                authorizationService.generate(
+                    new JsonObject(model.getUser()),
+                    model.getResponseType(),
+                    model.getMetaInfo(),
+                    tenantId))
+        .doOnSuccess(res -> passwordlessDao.deletePasswordlessModel(dto.getState(), tenantId));
+  }
+
+  private Single<PasswordlessModel> validateOtp(
+      PasswordlessModel model, String otp, String tenantId) {
+    if (model.getOtp().equals(otp)) {
+      return Single.just(model);
+    }
+
+    return passwordlessDao
+        .setPasswordlessModel(model.incRetry(), tenantId)
+        .map(
+            m -> {
+              throw INCORRECT_OTP.getCustomException(
+                  Map.of("retriesLeft", model.getMaxTries() - model.getTries()));
+            });
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/RevocationService.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/RevocationService.java
@@ -1,0 +1,54 @@
+package com.dreamsportslabs.guardian.service;
+
+import static com.dreamsportslabs.guardian.constant.Constants.REVOCATIONS_FLOOR_FACTOR;
+import static com.dreamsportslabs.guardian.constant.Constants.REVOCATIONS_KEY_SEPARATOR;
+
+import com.dreamsportslabs.guardian.cache.RevocationsCache;
+import com.dreamsportslabs.guardian.config.tenant.TenantConfig;
+import com.dreamsportslabs.guardian.dto.request.RevocationRequestDto;
+import com.dreamsportslabs.guardian.dto.response.RevocationsResponseDto;
+import com.dreamsportslabs.guardian.registry.Registry;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Single;
+import java.util.ArrayList;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class RevocationService {
+  private final RevocationsCache revocationsCache;
+  private final Registry registry;
+
+  public Single<RevocationsResponseDto> getRevocations(
+      RevocationRequestDto requestDto, String tenantId) {
+    TenantConfig config = registry.get(tenantId, TenantConfig.class);
+
+    Integer accessTokenExpiry = config.getTokenConfig().getAccessTokenExpiry();
+    requestDto.validate(accessTokenExpiry);
+
+    Long fromEpoch = getFloorTimestamp(requestDto.getFromEpoch());
+    Long toEpoch = getFloorTimestamp(requestDto.getToEpoch());
+    if (fromEpoch.equals(toEpoch)) {
+      return Single.just(
+          new RevocationsResponseDto(new ArrayList<>(), fromEpoch, toEpoch, accessTokenExpiry));
+    }
+    return revocationsCache
+        .getRevocationList(getRevocationKey(tenantId, fromEpoch, toEpoch))
+        .map(
+            revocations ->
+                new RevocationsResponseDto(revocations, fromEpoch, toEpoch, accessTokenExpiry));
+  }
+
+  private String getRevocationKey(String tenantId, Long fromTimestamp, Long toTimestamp) {
+    return tenantId
+        + REVOCATIONS_KEY_SEPARATOR
+        + fromTimestamp
+        + REVOCATIONS_KEY_SEPARATOR
+        + toTimestamp;
+  }
+
+  private Long getFloorTimestamp(Long epochSeconds) {
+    return epochSeconds - epochSeconds % REVOCATIONS_FLOOR_FACTOR;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/SocialAuthService.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/SocialAuthService.java
@@ -1,0 +1,178 @@
+package com.dreamsportslabs.guardian.service;
+
+import static com.dreamsportslabs.guardian.constant.Constants.FACEBOOK;
+import static com.dreamsportslabs.guardian.constant.Constants.GOOGLE;
+import static com.dreamsportslabs.guardian.constant.Constants.NO_PICTURE;
+import static com.dreamsportslabs.guardian.constant.Constants.USERID;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.USER_EXISTS;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.USER_NOT_EXISTS;
+
+import com.dreamsportslabs.guardian.constant.Flow;
+import com.dreamsportslabs.guardian.dto.Provider;
+import com.dreamsportslabs.guardian.dto.UserDto;
+import com.dreamsportslabs.guardian.dto.request.V1AuthFbRequestDto;
+import com.dreamsportslabs.guardian.dto.request.V1AuthGoogleRequestDto;
+import com.dreamsportslabs.guardian.registry.Registry;
+import com.dreamsportslabs.guardian.service.impl.idproviders.FacebookIdProvider;
+import com.dreamsportslabs.guardian.service.impl.idproviders.GoogleIdProvider;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class SocialAuthService {
+  private final UserService userService;
+  private final AuthorizationService authorizationService;
+  private final Registry registry;
+
+  public Single<Object> authFb(
+      V1AuthFbRequestDto dto, MultivaluedMap<String, String> headers, String tenantId) {
+    return registry
+        .get(tenantId, FacebookIdProvider.class)
+        .getUserIdentity(dto.getAccessToken())
+        .flatMap(
+            fbUserData ->
+                userService
+                    .getUser(
+                        Map.of(
+                            "email",
+                            fbUserData.getString("email"),
+                            "providerName",
+                            "facebook",
+                            "providerId",
+                            fbUserData.getString("id")),
+                        headers,
+                        tenantId)
+                    .map(res -> Pair.of(fbUserData, res)))
+        .flatMap(
+            userDetails -> {
+              JsonObject fbUserData = userDetails.getLeft();
+              JsonObject userRes = userDetails.getRight();
+
+              boolean userExists = userRes.getString(USERID) != null;
+              if (dto.getFlow() == Flow.SIGNIN && !userExists) {
+                return Single.error(USER_NOT_EXISTS.getException());
+              } else if (dto.getFlow() == Flow.SIGNUP && userExists) {
+                return Single.error(USER_EXISTS.getException());
+              }
+
+              if (!userExists) {
+                return userService.createUser(
+                    getUserDtoFromFbUserData(fbUserData, dto.getAccessToken()), headers, tenantId);
+              } else {
+                return userService
+                    .addProvider(
+                        userRes.getString(USERID),
+                        headers,
+                        getFbProviderData(fbUserData, dto.getAccessToken()),
+                        tenantId)
+                    .map(res -> userRes);
+              }
+            })
+        .flatMap(
+            user ->
+                authorizationService.generate(
+                    user, dto.getResponseType(), dto.getMetaInfo(), tenantId));
+  }
+
+  private UserDto getUserDtoFromFbUserData(JsonObject fbUserData, String accessToken) {
+    return UserDto.builder()
+        .name(fbUserData.getString("name"))
+        .firstName(fbUserData.getString("first_name"))
+        .middleName(fbUserData.getString("middle_name"))
+        .lastName(fbUserData.getString("last_name"))
+        .email(fbUserData.getString("email"))
+        .picture(
+            fbUserData.getJsonObject("picture", NO_PICTURE).getJsonObject("data").getString("url"))
+        .provider(getFbProviderData(fbUserData, accessToken))
+        .build();
+  }
+
+  private Provider getFbProviderData(JsonObject fbUserData, String accessToken) {
+    return Provider.builder()
+        .name(FACEBOOK)
+        .providerUserId(fbUserData.getString("id"))
+        .data(fbUserData.getMap())
+        .credentials(Map.of("access_token", accessToken))
+        .build();
+  }
+
+  public Single<Object> authGoogle(
+      V1AuthGoogleRequestDto dto, MultivaluedMap<String, String> headers, String tenantId) {
+    return registry
+        .get(tenantId, GoogleIdProvider.class)
+        .getUserIdentity(dto.getIdToken())
+        .flatMap(
+            googleUserData ->
+                userService
+                    .getUser(
+                        Map.of(
+                            "email",
+                            googleUserData.getString("email"),
+                            "providerName",
+                            "google",
+                            "providerId",
+                            googleUserData.getString("sub")),
+                        headers,
+                        tenantId)
+                    .map(res -> Pair.of(googleUserData, res)))
+        .flatMap(
+            userDetails -> {
+              JsonObject googleUserData = userDetails.getLeft();
+              JsonObject userRes = userDetails.getRight();
+
+              boolean userExists = userRes.getString(USERID) != null;
+              if (dto.getFlow() == Flow.SIGNIN && !userExists) {
+                return Single.error(USER_NOT_EXISTS.getException());
+              } else if (dto.getFlow() == Flow.SIGNUP && userExists) {
+                return Single.error(USER_EXISTS.getException());
+              }
+
+              if (!userExists) {
+                return userService.createUser(
+                    getUserDtoFromGoogleUserData(googleUserData, dto.getIdToken()),
+                    headers,
+                    tenantId);
+              } else {
+                return userService
+                    .addProvider(
+                        userRes.getString(USERID),
+                        headers,
+                        getGoogleProviderData(googleUserData, dto.getIdToken()),
+                        tenantId)
+                    .map(res -> userRes);
+              }
+            })
+        .flatMap(
+            user ->
+                authorizationService.generate(
+                    user, dto.getResponseType().getResponseType(), dto.getMetaInfo(), tenantId));
+  }
+
+  private UserDto getUserDtoFromGoogleUserData(JsonObject googleUserData, String idToken) {
+    return UserDto.builder()
+        .name(googleUserData.getString("name"))
+        .firstName(googleUserData.getString("given_name"))
+        .middleName(googleUserData.getString("middle_name"))
+        .lastName(googleUserData.getString("family_name"))
+        .email(googleUserData.getString("email"))
+        .picture(googleUserData.getString("picture"))
+        .provider(getGoogleProviderData(googleUserData, idToken))
+        .build();
+  }
+
+  private Provider getGoogleProviderData(JsonObject googleUserData, String idToken) {
+    return Provider.builder()
+        .name(GOOGLE)
+        .providerUserId(googleUserData.getString("id"))
+        .data(googleUserData.getMap())
+        .credentials(Map.of("id_token", idToken))
+        .build();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/TokenIssuer.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/TokenIssuer.java
@@ -1,0 +1,89 @@
+package com.dreamsportslabs.guardian.service;
+
+import static com.dreamsportslabs.guardian.constant.Constants.JWT_CLAIMS_EXP;
+import static com.dreamsportslabs.guardian.constant.Constants.JWT_CLAIMS_IAT;
+import static com.dreamsportslabs.guardian.constant.Constants.JWT_CLAIMS_ISS;
+import static com.dreamsportslabs.guardian.constant.Constants.JWT_CLAIMS_RFT_ID;
+import static com.dreamsportslabs.guardian.constant.Constants.JWT_CLAIMS_SUB;
+import static com.dreamsportslabs.guardian.constant.Constants.USERID;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INTERNAL_SERVER_ERROR;
+
+import com.dreamsportslabs.guardian.config.tenant.TenantConfig;
+import com.dreamsportslabs.guardian.registry.Registry;
+import com.google.inject.Inject;
+import io.fusionauth.jwt.JWTEncoder;
+import io.fusionauth.jwt.domain.JWT;
+import io.fusionauth.jwt.rsa.RSASigner;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.Vertx;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class TokenIssuer {
+  private final Vertx vertx;
+  private final JWTEncoder encoder = JWT.getEncoder();
+  private final Registry registry;
+
+  public Single<String> generateIdToken(JsonObject user, Long iat, TenantConfig config) {
+    JWT jwt =
+        getBaseJwt(
+            user.getString(USERID),
+            iat,
+            iat + config.getTokenConfig().getIdTokenExpiry(),
+            config.getTokenConfig().getIssuer());
+    config
+        .getTokenConfig()
+        .getIdTokenClaims()
+        .forEach(
+            claim -> {
+              Object value = user.getValue(claim);
+              if (value != null) {
+                jwt.addClaim(claim, value);
+              }
+            });
+
+    return signToken(jwt, config.getTenantId());
+  }
+
+  public Single<String> generateAccessToken(
+      String sub, Long iat, String rftId, TenantConfig config) {
+    JWT jwt =
+        getBaseJwt(
+                sub,
+                iat,
+                iat + config.getTokenConfig().getAccessTokenExpiry(),
+                config.getTokenConfig().getIssuer())
+            .addClaim(JWT_CLAIMS_RFT_ID, rftId);
+
+    return signToken(jwt, config.getTenantId());
+  }
+
+  public String generateRefreshToken() {
+    return RandomStringUtils.randomAlphanumeric(32);
+  }
+
+  private JWT getBaseJwt(String sub, Long iat, Long exp, String issuer) {
+    return new JWT()
+        .addClaim(JWT_CLAIMS_IAT, iat)
+        .addClaim(JWT_CLAIMS_SUB, sub)
+        .addClaim(JWT_CLAIMS_ISS, issuer)
+        .addClaim(JWT_CLAIMS_EXP, exp);
+  }
+
+  private Single<String> signToken(JWT jwt, String tenantId) {
+    return vertx
+        .rxExecuteBlocking(
+            future -> {
+              RSASigner signer = registry.get(tenantId, RSASigner.class);
+              future.complete(encoder.encode(jwt, signer));
+            },
+            false)
+        .switchIfEmpty(Single.error(INTERNAL_SERVER_ERROR.getException()))
+        .onErrorResumeNext(err -> Single.error(INTERNAL_SERVER_ERROR.getException(err)))
+        .map(String.class::cast);
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/UserService.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/UserService.java
@@ -1,0 +1,112 @@
+package com.dreamsportslabs.guardian.service;
+
+import static com.dreamsportslabs.guardian.constant.Constants.USERID;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INTERNAL_SERVER_ERROR;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.USER_SERVICE_ERROR;
+
+import com.dreamsportslabs.guardian.config.tenant.TenantConfig;
+import com.dreamsportslabs.guardian.config.tenant.UserConfig;
+import com.dreamsportslabs.guardian.dto.Provider;
+import com.dreamsportslabs.guardian.dto.UserDto;
+import com.dreamsportslabs.guardian.registry.Registry;
+import com.dreamsportslabs.guardian.utils.Utils;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.ext.web.client.HttpRequest;
+import io.vertx.rxjava3.ext.web.client.WebClient;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class UserService {
+  private final WebClient webClient;
+  private final Registry registry;
+
+  public Single<JsonObject> getUser(
+      Map<String, String> userFilters, MultivaluedMap<String, String> headers, String tenantId) {
+    UserConfig userConfig = registry.get(tenantId, TenantConfig.class).getUserConfig();
+
+    HttpRequest<Buffer> request =
+        webClient.get(userConfig.getPort(), userConfig.getHost(), userConfig.getGetUserPath());
+    userFilters.forEach(request::addQueryParam);
+    return request
+        .putHeaders(Utils.getForwardingHeaders(headers))
+        .ssl(userConfig.getIsSslEnabled())
+        .rxSend()
+        .onErrorResumeNext(err -> Single.error(INTERNAL_SERVER_ERROR.getException(err)))
+        .map(
+            res -> {
+              JsonObject resBody = res.bodyAsJsonObject();
+              if (res.statusCode() / 100 != 2) {
+                throw USER_SERVICE_ERROR.getCustomException(resBody.getMap());
+              }
+              return resBody;
+            });
+  }
+
+  public Single<JsonObject> createUser(
+      UserDto dto, MultivaluedMap<String, String> headers, String tenantId) {
+    UserConfig userConfig = registry.get(tenantId, TenantConfig.class).getUserConfig();
+    return webClient
+        .post(userConfig.getPort(), userConfig.getHost(), userConfig.getCreateUserPath())
+        .ssl(userConfig.getIsSslEnabled())
+        .putHeaders(Utils.getForwardingHeaders(headers))
+        .rxSendJson(dto)
+        .onErrorResumeNext(err -> Single.error(INTERNAL_SERVER_ERROR.getException(err)))
+        .map(
+            res -> {
+              JsonObject resBody = res.bodyAsJsonObject();
+              if (res.statusCode() / 100 != 2 || !resBody.containsKey(USERID)) {
+                throw USER_SERVICE_ERROR.getCustomException(resBody.getMap());
+              } else if (!resBody.containsKey(USERID)) {
+                throw USER_SERVICE_ERROR.getException();
+              }
+              return resBody.put("isNewUser", true);
+            });
+  }
+
+  public Single<JsonObject> authenticate(
+      UserDto dto, MultivaluedMap<String, String> headers, String tenantId) {
+    UserConfig userConfig = registry.get(tenantId, TenantConfig.class).getUserConfig();
+    return webClient
+        .post(userConfig.getPort(), userConfig.getHost(), userConfig.getAuthenticateUserPath())
+        .ssl(userConfig.getIsSslEnabled())
+        .putHeaders(Utils.getForwardingHeaders(headers))
+        .rxSendJson(dto)
+        .onErrorResumeNext(err -> Single.error(INTERNAL_SERVER_ERROR.getException(err)))
+        .map(
+            res -> {
+              JsonObject resBody = res.bodyAsJsonObject();
+              if (res.statusCode() != 200) {
+                throw USER_SERVICE_ERROR.getCustomException(resBody.getMap());
+              } else if (!resBody.containsKey(USERID)) {
+                throw USER_SERVICE_ERROR.getException();
+              }
+              return res.bodyAsJsonObject();
+            });
+  }
+
+  public Single<JsonObject> addProvider(
+      String userId, MultivaluedMap<String, String> headers, Provider provider, String tenantId) {
+    UserConfig userConfig = registry.get(tenantId, TenantConfig.class).getUserConfig();
+    return webClient
+        .post(userConfig.getPort(), userConfig.getHost(), userConfig.getAddProviderPath())
+        .ssl(userConfig.getIsSslEnabled())
+        .putHeaders(Utils.getForwardingHeaders(headers))
+        .rxSendJson(new JsonObject().put(USERID, userId).put("provider", provider))
+        .onErrorResumeNext(err -> Single.error(INTERNAL_SERVER_ERROR.getException(err)))
+        .map(
+            res -> {
+              JsonObject resBody = res.bodyAsJsonObject();
+              if (res.statusCode() / 100 != 2) {
+                throw USER_SERVICE_ERROR.getCustomException(resBody.getMap());
+              }
+              return resBody;
+            });
+  }
+}


### PR DESCRIPTION
## **User description**
@coderabbitai ignore


___

## **CodeAnt-AI Description**
- Introduces a comprehensive set of REST endpoints for authentication, registration, passwordless login, social login (Facebook and Google), token refresh, logout, and health checks.
- Implements core authentication and user management services, including password-based and passwordless flows, OTP delivery, token issuance, and revocation management.
- Adds robust error handling with standardized error responses and exception mappers.
- Provides interfaces and implementations for MySQL client management and identity provider integration.
- Integrates with external services (user, SMS, email) and supports multi-tenant configuration via a registry.
- Adds documentation and module generation annotations for Vert.x.

This PR establishes the foundational backend logic for an authentication service, covering all major authentication flows (password, passwordless, social), error handling, and extensibility for multi-tenant environments. The changes provide a scalable and maintainable structure for user and token management, improving reliability and developer experience.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>24 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>MysqlClient.java</strong><dd><code>Add MysqlClient interface for MySQL pool management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/client/MysqlClient.java
<li>Introduces a new interface <code>MysqlClient</code> for managing MySQL connection <br>pools.<br> <li> Defines methods for obtaining writer and reader pools and for <br>asynchronous connect/close operations.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-137c1b1407a36fb2b8fcf80ac2852b64962816868a71c4f8746cf0d47d54055e">+15/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>MysqlClientImpl.java</strong><dd><code>Implement MysqlClient with Vert.x MySQL pool logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/client/impl/MysqlClientImpl.java
<li>Implements the <code>MysqlClient</code> interface.<br> <li> Adds logic to create and manage separate writer and reader MySQL <br>connection pools using Vert.x and RxJava.<br> <li> Handles configuration via injected JSON and provides asynchronous <br>close operations.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-988f44317828a474e2b0c21d043593d22817698832f9de887dc618fa34febdd1">+75/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>ErrorEnum.java</strong><dd><code>Add ErrorEnum for standardized error handling and responses</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/exception/ErrorEnum.java
<li>Introduces <code>ErrorEnum</code> for standardized error handling and response <br>construction.<br> <li> Provides utility methods for generating exceptions with custom <br>messages and metadata.<br> <li> Defines a nested error entity structure for consistent error <br>responses.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-032f10a973678e9645102c26ccb70c7925f2c9373252e0787a9fd50a935d869f">+111/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>GenericExceptionMapper.java</strong><dd><code>Add generic exception mapper for unhandled errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/exception/GenericExceptionMapper.java
<li>Adds a JAX-RS exception mapper for generic <code>Throwable</code> exceptions.<br> <li> Logs errors and returns a standardized internal server error response.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-ddcf7e18f7a39326fba8d3982f0a35e3095372303deb954bcec0c07bdc095af9">+18/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>WebApplicationExceptionMapper.java</strong><dd><code>Add WebApplicationException mapper for consistent error responses</code></dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/exception/WebApplicationExceptionMapper.java
<li>Adds a JAX-RS exception mapper for <code>WebApplicationException</code>.<br> <li> Logs the exception and returns its response.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-22def7a60931359ec5bf0133f5e880f2c116cb235e4c46cf88d58c3bc664ecd8">+18/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>AuthFb.java</strong><dd><code>Add Facebook authentication REST endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/rest/AuthFb.java
<li>Adds a REST endpoint for Facebook authentication.<br> <li> Validates request, extracts tenant ID, and delegates to <br><code>SocialAuthService</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-f59e0ec1023871b92fbf8e0e6cbd6efd5f135655807fb4223ce877dc343f97d6">+37/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>AuthGoogle.java</strong><dd><code>Add Google authentication REST endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/rest/AuthGoogle.java
<li>Adds a REST endpoint for Google authentication.<br> <li> Validates request, extracts tenant ID, and delegates to <br><code>SocialAuthService</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-5eb05ab4706f60bee3efa77c47432da4626312311d5cf31d4d75f2f4e379704a">+39/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>CodeTokenExchange.java</strong><dd><code>Add code-token exchange REST endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/rest/CodeTokenExchange.java
<li>Adds a REST endpoint for code-token exchange.<br> <li> Validates request and delegates to <code>AuthorizationService</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-ace7c62ec65940e56cbd837263bbb7fa5d187d63d17f788dda2417a444663f92">+37/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthCheck.java</strong><dd><code>Add health check REST endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/rest/HealthCheck.java
<li>Adds a health check REST endpoint for service monitoring.<br> <li> Returns a simple OK response asynchronously.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-33634a9c7336af7d8da25806fe710957de6afc71d949adba67044f5e4930bcfb">+27/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Login.java</strong><dd><code>Add login REST endpoint for user authentication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/rest/Login.java
<li>Adds a REST endpoint for user login.<br> <li> Validates request, extracts tenant ID, and delegates to <code>PasswordAuth</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-9b9a717834e6a4ca3756ace0924fa8faa04412449fad0169bc2b36e98edcdce9">+39/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Logout.java</strong><dd><code>Add logout REST endpoint for user session termination</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/rest/Logout.java
<li>Adds a REST endpoint for user logout.<br> <li> Handles null request DTOs and delegates to <code>AuthorizationService</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-c647f5ab38e98a8450c71361bb4b688842b323f321a1bfc91ae24e5483883deb">+43/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>PasswordlessComplete.java</strong><dd><code>Add passwordless complete REST endpoint for OTP verification</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/rest/PasswordlessComplete.java
<li>Adds a REST endpoint to complete passwordless authentication.<br> <li> Validates OTP and delegates to <code>Passwordless</code> service.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-b5eff6d7a3716a8d2680da8486d1232073d9a6e207735a927ac001579daa3bfa">+36/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>PasswordlessInit.java</strong><dd><code>Add passwordless init REST endpoint for OTP initiation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/rest/PasswordlessInit.java
<li>Adds a REST endpoint to initiate passwordless authentication.<br> <li> Validates request and delegates to <code>Passwordless</code> service.<br> <li> Constructs a detailed response with retry and resend information.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-3c232f2974f0d4faa8a3ff7c41af9375da37aa77b215aee15a26e93dfdfa3bdb">+50/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RefreshToken.java</strong><dd><code>Add refresh token REST endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/rest/RefreshToken.java
<li>Adds a REST endpoint for refreshing authentication tokens.<br> <li> Validates request and delegates to <code>AuthorizationService</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-54c823b46a0ed6895e6e880bdb0d87c2297cef4283adcbdda9e57d942e376715">+36/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Register.java</strong><dd><code>Add register REST endpoint for user signup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/rest/Register.java
<li>Adds a REST endpoint for user registration.<br> <li> Validates request and delegates to <code>PasswordAuth</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-8209f9b136f6fcd155376045276ace099d4b6131f7c5c400ff22d8ad8b717c48">+39/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Revocations.java</strong><dd><code>Add revocations REST endpoint for token management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/rest/Revocations.java
<li>Adds a REST endpoint to retrieve token revocations.<br> <li> Delegates to <code>RevocationService</code> for business logic.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-bb3664e1f4f91d4961f03c0fd48c2ef4d8b0e31d9a1da5b28c5ddce1575a9316">+37/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>IdProvider.java</strong><dd><code>Add IdProvider interface for identity retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/service/IdProvider.java
<li>Introduces <code>IdProvider</code> interface for retrieving user identity from <br>authorization tokens.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-c72d7c4e75c750f2d48b3cd178d8b4f83293b93f5faa451df942daff67c04db4">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>OtpService.java</strong><dd><code>Add OtpService for sending OTP via SMS and Email</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/service/OtpService.java
<li>Implements OTP sending logic via SMS and Email using tenant <br>configuration.<br> <li> Handles error scenarios and integrates with external services.<br> <li> Supports sending OTP to multiple contacts.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-d8a72e89e787184023bb9f24eda135b166d9e16ede413bbf2dcd65d0ea5a2e53">+92/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>PasswordAuth.java</strong><dd><code>Add PasswordAuth service for login and registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/service/PasswordAuth.java
<li>Implements password-based authentication and registration logic.<br> <li> Integrates with <code>UserService</code> and <code>AuthorizationService</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-b568e8bfd48b5f4f70fcc26d65aa20fcd5e52bf9da703ca352d5258eb0c3604b">+51/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>Passwordless.java</strong><dd><code>Add Passwordless service for OTP-based authentication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/service/Passwordless.java
<li>Implements passwordless authentication flow with OTP management.<br> <li> Handles OTP generation, validation, retry/resend logic, and user <br>creation.<br> <li> Integrates with user, OTP, and authorization services.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-29bf88b6b28c0b24d4ee636d899e3bc117482d9a1aca4e96d71f76ed1b1ab6c3">+236/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>RevocationService.java</strong><dd><code>Add RevocationService for token revocation retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/service/RevocationService.java
<li>Implements logic for retrieving token revocations based on time <br>intervals.<br> <li> Integrates with revocation cache and tenant configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-a36dec6109e99f3549c483f77beec1e046f411845e08e2f86447d5d0500f365b">+54/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>SocialAuthService.java</strong><dd><code>Add SocialAuthService for Facebook and Google authentication</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/service/SocialAuthService.java
<li>Implements social authentication logic for Facebook and Google.<br> <li> Handles user existence checks, user creation, and provider linking.<br> <li> Integrates with authorization and user services.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-b607dab0b0ce278c02045665d765886facc37f6e38d15369b5794ca8686b0cd7">+178/-0</a>&nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>TokenIssuer.java</strong><dd><code>Add TokenIssuer service for JWT token generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/service/TokenIssuer.java
<li>Implements JWT token issuance logic for ID, access, and refresh <br>tokens.<br> <li> Uses FusionAuth JWT library and tenant-specific configuration.<br> <li> Handles signing and error scenarios.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-2a9844908ae74ac0c5f5500da0acd521d9ae9554eb5f27dc13e6c9a99c1ae295">+89/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>UserService.java</strong><dd><code>Add UserService for user management and provider linking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/service/UserService.java
<li>Implements user management logic including retrieval, creation, <br>authentication, and provider linking.<br> <li> Integrates with external user service via HTTP and handles errors.<br>


</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-9deb2acaa73bec2b78b2e25624c3c7f9c7361cc94980e94e387ef6d797199a80">+112/-0</a>&nbsp; </td>
</tr>
</table></details></td></tr><tr><td><strong>Documentation
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>package-info.java</strong><dd><code>Add package-info with Vert.x ModuleGen annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/dreamsportslabs/guardian/package-info.java
- Adds a package-info file with Vert.x module generation annotation.



</details>


  </td>
  <td><a href="https://github.com/ObitoUchiha01011998/guardian/pull/10/files#diff-d6501428ee631685e9c3d6c926a1886b5fb69d359ef6f2203b663b1d75714e57">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></details></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
